### PR TITLE
CSCvi45267 "at" keyword acts as a filter for the version of an object

### DIFF
--- a/expand_parser.go
+++ b/expand_parser.go
@@ -21,6 +21,7 @@ var GlobalExpandTokenizer = ExpandTokenizer()
 type ExpandItem struct {
 	Path    []*Token
 	Filter  *GoDataFilterQuery
+	At      *GoDataFilterQuery
 	Search  *GoDataSearchQuery
 	OrderBy *GoDataOrderByQuery
 	Skip    *GoDataSkipQuery
@@ -167,6 +168,15 @@ func ParseExpandOption(queue *tokenQueue, item *ExpandItem) error {
 		filter, err := ParseFilterString(body)
 		if err == nil {
 			item.Filter = filter
+		} else {
+			return err
+		}
+	}
+
+	if head == "at" {
+		at, err := ParseFilterString(body)
+		if err == nil {
+			item.At = at
 		} else {
 			return err
 		}

--- a/request_model.go
+++ b/request_model.go
@@ -65,6 +65,7 @@ type GoDataSegment struct {
 
 type GoDataQuery struct {
 	Filter      *GoDataFilterQuery
+	At          *GoDataFilterQuery
 	Apply       *GoDataApplyQuery
 	Expand      *GoDataExpandQuery
 	Select      *GoDataSelectQuery

--- a/url_parser.go
+++ b/url_parser.go
@@ -206,6 +206,7 @@ func SemanticizePathSegment(segment *GoDataSegment, service *GoDataService) erro
 
 func ParseUrlQuery(query url.Values) (*GoDataQuery, error) {
 	filter := query.Get("$filter")
+	at := query.Get("at")
 	apply := query.Get("$apply")
 	expand := query.Get("$expand")
 	sel := query.Get("$select")
@@ -221,6 +222,9 @@ func ParseUrlQuery(query url.Values) (*GoDataQuery, error) {
 
 	var err error = nil
 	if filter != "" {
+		result.Filter, err = ParseFilterString(filter)
+	}
+	if at != "" {
 		result.Filter, err = ParseFilterString(filter)
 	}
 	if err != nil {

--- a/url_parser.go
+++ b/url_parser.go
@@ -225,7 +225,7 @@ func ParseUrlQuery(query url.Values) (*GoDataQuery, error) {
 		result.Filter, err = ParseFilterString(filter)
 	}
 	if at != "" {
-		result.Filter, err = ParseFilterString(filter)
+		result.At, err = ParseFilterString(at)
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- The keyword "at" will now be parsed as a filter by godata. We use this as another filter to specify the version of the object we want. For example: 

https://ucs.cisco.com/api/v1/<package name>/<class name>/<moid>?at=versionType eq 'config' and interestedMos.refMo.Moid eq <moid>

The above would fetch the versions of the object with versionType equal to config. "at" is also supported on class queries:
https://ucs.cisco.com/api/v1/<package name>/<class name>?at=versionType eq 'config' and interestedMos.refMo.Moid eq <moid>
