### PR TITLE
Stricter tokenization and parsing of ODATA parameters

### DIFF
--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -471,6 +471,9 @@ func TestInvalidFilterSyntax(t *testing.T) {
 		"City eq",                 // Missing operand
 		"City eq (",               // Wrong operand
 		"City eq )",               // Wrong operand
+		"City near 'Dallas'",      // Unknown operator that starts with the same letters as a known operator
+		"City equals 'Dallas'",    // Unknown operator that starts with the same letters as a known operator
+		"City isNot 'Dallas'",     // Unknown operator
 		"not [City eq 'Dallas']",  // Wrong delimiter
 		"not (City eq )",          // Missing operand
 		"not ((City eq 'Dallas'",  // Missing closing parenthesis
@@ -1045,6 +1048,7 @@ func TestFilterTokenizerExists(t *testing.T) {
 		t.Error(err)
 	}
 }
+
 // CompareTree compares a tree representing a ODATA filter with the expected results.
 // The expected values are a slice of nodes in breadth-first traversal.
 func CompareTree(node *ParseNode, expect []expectedParseNode, pos *int, level int) error {

--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -22,10 +22,11 @@ func TestFilterDateTime(t *testing.T) {
 	for tokenValue, tokenType := range tokens {
 		// Previously, the unit test had no space character after 'gt'
 		// E.g. 'CreateTime gt2011-08-29T21:58Z' was considered valid.
-		// However the ABNF notation for logical operators is:
-		// gtExpr = RWS "gt" RWS commonExpr
-		// RWS = 1*( SP / HTAB / "%20" / "%09" )  ; "required" whitespace
-		// http://docs.oasis-open.org/odata/odata/v4.01/csprd03/abnf/odata-abnf-construction-rules.txt
+		// However the ABNF notation for ODATA logical operators is:
+		//   gtExpr = RWS "gt" RWS commonExpr
+		//   RWS = 1*( SP / HTAB / "%20" / "%09" )  ; "required" whitespace
+		//
+		// See http://docs.oasis-open.org/odata/odata/v4.01/csprd03/abnf/odata-abnf-construction-rules.txt
 		input := "CreateTime gt " + tokenValue
 		expect := []*Token{
 			&Token{Value: "CreateTime", Type: FilterTokenLiteral},

--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -2,6 +2,7 @@ package godata
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 )
 
@@ -19,7 +20,13 @@ func TestFilterDateTime(t *testing.T) {
 		"21:58:33":                      FilterTokenTime,
 	}
 	for tokenValue, tokenType := range tokens {
-		input := "CreateTime gt" + tokenValue
+		// Previously, the unit test had no space character after 'gt'
+		// E.g. 'CreateTime gt2011-08-29T21:58Z' was considered valid.
+		// However the ABNF notation for logical operators is:
+		// gtExpr = RWS "gt" RWS commonExpr
+		// RWS = 1*( SP / HTAB / "%20" / "%09" )  ; "required" whitespace
+		// http://docs.oasis-open.org/odata/odata/v4.01/csprd03/abnf/odata-abnf-construction-rules.txt
+		input := "CreateTime gt " + tokenValue
 		expect := []*Token{
 			&Token{Value: "CreateTime", Type: FilterTokenLiteral},
 			&Token{Value: "gt", Type: FilterTokenLogical},
@@ -27,12 +34,17 @@ func TestFilterDateTime(t *testing.T) {
 		}
 		output, err := tokenizer.Tokenize(input)
 		if err != nil {
-			t.Error(err)
+			t.Errorf("Failed to tokenize input %s. Error: %v", input, err)
 		}
 
 		result, err := CompareTokens(expect, output)
 		if !result {
-			t.Error(err)
+			var a []string
+			for _, t := range output {
+				a = append(a, t.Value)
+			}
+
+			t.Errorf("Unexpected tokens for input '%s'. Tokens: %s Error: %v", input, strings.Join(a, ", "), err)
 		}
 	}
 }
@@ -410,7 +422,9 @@ func TestValidFilterSyntax(t *testing.T) {
 		"geo.intersects(Position,TargetArea)",
 		// Logical operators
 		"Name eq 'Milk'",
+		"Name EQ 'Milk'", // operators are case insensitive in ODATA 4.0.1
 		"Name ne 'Milk'",
+		"Name NE 'Milk'",
 		"Name gt 'Milk'",
 		"Name ge 'Milk'",
 		"Name lt 'Milk'",
@@ -421,7 +435,9 @@ func TestValidFilterSyntax(t *testing.T) {
 		//"style has Sales.Pattern'Yellow'", // TODO
 		// Arithmetic operators
 		"Price add 2.45 eq 5.00",
+		"Price ADD 2.45 eq 5.00", // 4.01 Services MUST support case-insensitive operator names.
 		"Price sub 0.55 eq 2.00",
+		"Price SUB 0.55 EQ 2.00", // 4.01 Services MUST support case-insensitive operator names.
 		"Price mul 2.0 eq 5.10",
 		"Price div 2.55 eq 1",
 		"Rating div 2 eq 2",
@@ -468,11 +484,13 @@ func TestValidFilterSyntax(t *testing.T) {
 // The URLs below are not valid ODATA syntax, the parser should return an error.
 func TestInvalidFilterSyntax(t *testing.T) {
 	queries := []string{
+		//"City",                    // Just a single literal
+		"City City City City",     // Sequence of literals
 		"City eq",                 // Missing operand
 		"City eq (",               // Wrong operand
 		"City eq )",               // Wrong operand
-		"City near 'Dallas'",      // Unknown operator that starts with the same letters as a known operator
 		"City equals 'Dallas'",    // Unknown operator that starts with the same letters as a known operator
+		"City near 'Dallas'",      // Unknown operator that starts with the same letters as a known operator
 		"City isNot 'Dallas'",     // Unknown operator
 		"not [City eq 'Dallas']",  // Wrong delimiter
 		"not (City eq )",          // Missing operand
@@ -489,7 +507,7 @@ func TestInvalidFilterSyntax(t *testing.T) {
 		"contains(LastName, 'Smith'))", // Extraneous closing parenthesis
 		"contains(LastName, 'Smith'",   // Missing closing parenthesis
 		"contains LastName, 'Smith')",  // Missing open parenthesis
-		//"City eq 'Dallas' 'Houston'",   // extraneous string value
+		"City eq 'Dallas' 'Houston'",   // extraneous string value
 		//"contains(Name, 'a', 'b', 'c', 'd')", // Too many function arguments
 	}
 	for _, input := range queries {

--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -394,6 +394,8 @@ func TestValidFilterSyntax(t *testing.T) {
 		"month(BirthDate) eq 12",
 		"day(StartTime) eq 8",
 		"hour(StartTime) eq 1",
+		"hour    (StartTime) eq 1",     // function followed by space characters
+		"hour    ( StartTime   ) eq 1", // function followed by space characters
 		"minute(StartTime) eq 0",
 		"second(StartTime) eq 0",
 		"date(StartTime) ne date(EndTime)",
@@ -484,7 +486,14 @@ func TestValidFilterSyntax(t *testing.T) {
 // The URLs below are not valid ODATA syntax, the parser should return an error.
 func TestInvalidFilterSyntax(t *testing.T) {
 	queries := []string{
-		//"City",                    // Just a single literal
+		"",                        // Nothing
+		"eq",                      // Just a single logical operator
+		"and",                     // Just a single logical operator
+		"add",                     // Just a single arithmetic operator
+		"add ",                    // Just a single arithmetic operator
+		"add 2",                   // Missing operands
+		"add 2 3",                 // Missing operands
+		"City",                    // Just a single literal
 		"City City City City",     // Sequence of literals
 		"City eq",                 // Missing operand
 		"City eq (",               // Wrong operand
@@ -729,6 +738,10 @@ func TestFilterParserTree(t *testing.T) {
 }
 
 func printTree(n *ParseNode, level int) {
+	if n == nil || n.Token == nil {
+		fmt.Printf("\n")
+		return
+	}
 	indent := ""
 	for i := 0; i < level; i++ {
 		indent += "  "

--- a/parser.go
+++ b/parser.go
@@ -55,7 +55,6 @@ func (t *Tokenizer) Ignore(pattern string, token int) {
 func (t *Tokenizer) TokenizeBytes(target []byte) ([]*Token, error) {
 	result := make([]*Token, 0)
 	match := true // false when no match is found
-
 	for len(target) > 0 && match {
 		match = false
 		ignore := false

--- a/parser.go
+++ b/parser.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strings"
 )
 
 const (
@@ -24,9 +25,10 @@ type Tokenizer struct {
 }
 
 type TokenMatcher struct {
-	Pattern string         // The regular expression matching a ODATA query token, such as literal value, operator or function
-	Re      *regexp.Regexp // The compiled regex
-	Token   int
+	Pattern         string         // The regular expression matching a ODATA query token, such as literal value, operator or function
+	Re              *regexp.Regexp // The compiled regex
+	Token           int            // The token identifier
+	CaseInsentitive bool           // Regex is case-insensitive
 }
 
 type Token struct {
@@ -40,37 +42,58 @@ type Token struct {
 
 func (t *Tokenizer) Add(pattern string, token int) {
 	rxp := regexp.MustCompile(pattern)
-	matcher := &TokenMatcher{pattern, rxp, token}
+	matcher := &TokenMatcher{pattern, rxp, token, strings.Contains(pattern, "(?i)")}
 	t.TokenMatchers = append(t.TokenMatchers, matcher)
 }
 
 func (t *Tokenizer) Ignore(pattern string, token int) {
 	rxp := regexp.MustCompile(pattern)
-	matcher := &TokenMatcher{pattern, rxp, token}
+	matcher := &TokenMatcher{pattern, rxp, token, strings.Contains(pattern, "(?i)")}
 	t.IgnoreMatchers = append(t.IgnoreMatchers, matcher)
 }
 
 func (t *Tokenizer) TokenizeBytes(target []byte) ([]*Token, error) {
 	result := make([]*Token, 0)
 	match := true // false when no match is found
+
 	for len(target) > 0 && match {
 		match = false
-		for _, m := range t.TokenMatchers {
-			token := m.Re.Find(target)
-			if len(token) > 0 {
-				parsed := Token{Value: string(token), Type: m.Token}
-				result = append(result, &parsed)
-				target = target[len(token):] // remove the token from the input
+		ignore := false
+		var tokens [][]byte
+		var m *TokenMatcher
+		for _, m = range t.TokenMatchers {
+			tokens = m.Re.FindSubmatch(target)
+			if len(tokens) > 0 {
 				match = true
 				break
 			}
 		}
-		for _, m := range t.IgnoreMatchers {
-			token := m.Re.Find(target)
-			if len(token) > 0 {
-				match = true
-				target = target[len(token):] // remove the token from the input
-				break
+		if len(tokens) == 0 {
+			for _, m = range t.IgnoreMatchers {
+				tokens = m.Re.FindSubmatch(target)
+				if len(tokens) > 0 {
+					ignore = true
+					break
+				}
+			}
+		}
+		if len(tokens) > 0 {
+			match = true
+			var parsed Token
+			var token []byte
+			if idx := m.Re.SubexpIndex("token"); idx > 0 {
+				token = tokens[idx]
+			} else {
+				token = tokens[0]
+			}
+			target = target[len(token):] // remove the token from the input
+			if !ignore {
+				if m.CaseInsentitive {
+					parsed = Token{Value: strings.ToLower(string(token)), Type: m.Token}
+				} else {
+					parsed = Token{Value: string(token), Type: m.Token}
+				}
+				result = append(result, &parsed)
 			}
 		}
 	}
@@ -151,13 +174,38 @@ func (p *Parser) isGroupingOperator(stack *tokenStack, token *Token) bool {
 	return false
 }
 
-// Parse the input string of tokens using the given definitions of operators
+// IsLiteral returns true if the specified token is considered a literal for this parser.
+func (p *Parser) IsLiteral(token *Token) bool {
+	if token.Value == "," || token.Value == "(" || token.Value == ")" {
+		return false
+	}
+	if _, ok := p.Functions[token.Value]; ok {
+		return false
+	}
+	if _, ok := p.Operators[token.Value]; ok {
+		return false
+	}
+	return true
+}
+
+// InfixToPostfix parses the input string of tokens using the given definitions of operators
 // and functions. (Everything else is assumed to be a literal.) Uses the
 // Shunting-Yard algorithm.
 func (p *Parser) InfixToPostfix(tokens []*Token) (*tokenQueue, error) {
 	queue := tokenQueue{} // output queue in postfix
 	stack := tokenStack{} // Operator stack
 
+	prevIsLiteral := false
+	for i := range tokens {
+		isLiteral := p.IsLiteral(tokens[i])
+		if isLiteral && prevIsLiteral {
+			// Cannot have two consecutive literal values.
+			return nil, BadRequestError(
+				fmt.Sprintf("Request cannot include two consecutive literal values '%v' and '%v'",
+					tokens[i-1].Value, tokens[i].Value))
+		}
+		prevIsLiteral = isLiteral
+	}
 	for len(tokens) > 0 {
 		token := tokens[0]
 		tokens = tokens[1:]
@@ -400,6 +448,7 @@ type tokenQueueNode struct {
 	Next  *tokenQueueNode
 }
 
+// Enqueue adds the specified token at the tail of the queue.
 func (q *tokenQueue) Enqueue(t *Token) {
 	node := tokenQueueNode{t, q.Tail, nil}
 	//fmt.Println(t.Value)

--- a/parser.go
+++ b/parser.go
@@ -81,6 +81,15 @@ func (t *Tokenizer) TokenizeBytes(target []byte) ([]*Token, error) {
 			match = true
 			var parsed Token
 			var token []byte
+			// If the regex includes a named group and the name of that group is "token"
+			// then the value of the token is set to the subgroup. Other characters are
+			// not consumed by the tokenization process.
+			// For example, the regex:
+			//    ^(?P<token>(eq|ne|gt|ge|lt|le|and|or|not|has|in))\\s
+			// has a group named 'token' and the group is followed by a mandatory space character.
+			// If the input data is `Name eq 'Bob'`, the token is correctly set to 'eq' and
+			// the space after eq is not consumed, because the space character itself is supposed
+			// to be the next token.
 			if idx := m.Re.SubexpIndex("token"); idx > 0 {
 				token = tokens[idx]
 			} else {

--- a/parser.go
+++ b/parser.go
@@ -101,7 +101,9 @@ func (t *Tokenizer) TokenizeBytes(target []byte) ([]*Token, error) {
 	if len(target) > 0 && !match {
 		return result, BadRequestError("No matching token for " + string(target))
 	}
-
+	if len(result) <= 1 {
+		return result, BadRequestError("Missing parameter for " + string(target))
+	}
 	return result, nil
 }
 

--- a/parser.go
+++ b/parser.go
@@ -98,6 +98,7 @@ func (t *Tokenizer) TokenizeBytes(target []byte) ([]*Token, error) {
 			target = target[len(token):] // remove the token from the input
 			if !ignore {
 				if m.CaseInsentitive {
+					// In ODATA 4.0.1, operators and functions are case insensitive.
 					parsed = Token{Value: strings.ToLower(string(token)), Type: m.Token}
 				} else {
 					parsed = Token{Value: string(token), Type: m.Token}

--- a/service_test.go
+++ b/service_test.go
@@ -197,7 +197,7 @@ func TestSemanticizeRequestWildcard(t *testing.T) {
 	err = SemanticizeRequest(req, service)
 
 	if err != nil {
-		t.Error(err)
+		t.Errorf("Failed to semanticize request. Error: %v", err)
 		return
 	}
 

--- a/url_parser_test.go
+++ b/url_parser_test.go
@@ -109,6 +109,55 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		return
 	}
 
+	testUrl = "Employees(1)/Sales.Manager?$filter=Name in ('Bob','Alice')&$select=Name,Address%3B$expand=Address($select=City)"
+	parsedUrl, err = url.Parse(testUrl)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	_, err = ParseRequest(parsedUrl.Path, parsedUrl.Query(), false /*strict*/)
+	if err != nil {
+		t.Errorf("Unexpected parsing error: %v", err)
+		return
+	}
+
+	// A $select option cannot be wrapped with parenthesis. This is not legal ODATA.
+
+	/*
+		 queryOptions = queryOption *( "&" queryOption )
+		 queryOption  = systemQueryOption
+				/ aliasAndValue
+				/ nameAndValue
+				/ customQueryOption
+		 systemQueryOption = compute
+				/ deltatoken
+				/ expand
+				/ filter
+				/ format
+				/ id
+				/ inlinecount
+				/ orderby
+				/ schemaversion
+				/ search
+				/ select
+				/ skip
+				/ skiptoken
+				/ top
+				/ index
+		  select = ( "$select" / "select" ) EQ selectItem *( COMMA selectItem )
+	*/
+	testUrl = "Employees(1)/Sales.Manager?$filter=Name in ('Bob','Alice')&($select=Name,Address%3B$expand=Address($select=City))"
+	parsedUrl, err = url.Parse(testUrl)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	_, err = ParseRequest(parsedUrl.Path, parsedUrl.Query(), false /*strict*/)
+	if err == nil {
+		t.Errorf("Parser should have raised error")
+		return
+	}
+
 	// Duplicate keywords
 	testUrl = "Employees(1)/Sales.Manager?$select=3DFirstName&$select=3DFirstName"
 	parsedUrl, err = url.Parse(testUrl)


### PR DESCRIPTION
* In ODATA 4.01, services MUST support case-insensitive operator and function names. Both forms are now supported:
    * `Name EQ 'Milk'` // Previously this was not working
    * `Name eq 'Milk'`
* Operator/function are converted to lowercase during tokenization
* Operators must now be followed by space character (as per ODATA ABNF grammar).
    * `CreateTime gt2011-08-29T21:58:33-11:23` is not valid // previously this was processed
    * `CreateTime gt 2011-08-29T21:58:33-11:23` is valid
* Consecutive literals now cause error
    * `Name eq 'Milk' 'Coke'` // Now raises error. This used to be processed as `Name eq 'Milk'`
    * `$filter='Milk' 'Milk' 'Milk'` // Now raises error, used to return valid odata tree
* Stricter tokenization of operators
   * `Name equals 'Milk'` // No longer supported. Used to be interpreted as `Name eq uals`
   * `hour(StartTime) eq 1` // valid
   * `hourOfDay(StartTime) eq 1` // no longer valid
   * `'Milk'` // single literal, no longer valid
   * `` // empty string, no longer valid
* Add unit test that shows ODATA options ($select, $top, $filter...) cannot be surrounded by parenthesis group.

According to ODATA ABNF notation, `$filter=<primitive literal>` is valid ODATA. I can't find a example that would make sense, this PR raises error in that case.

```abnf
filter = ( "$filter" / "filter" ) EQ boolCommonExpr
commonExpr = ( primitiveLiteral
             / parameterAlias
             / arrayOrObject
             / rootExpr
             / firstMemberExpr
             / functionExpr
            )
boolCommonExpr = commonExpr ; resulting in a Boolean
primitiveLiteral = nullValue                  ; plain values up to int64Value
                 / booleanValue 
                 / guidValue 
                 / dateValue
                 / dateTimeOffsetValue 
                 / timeOfDayValue
                 / decimalValue 
                 / doubleValue 
```