### PR TITLE
Add unit tests: any without arguments and any for array of strings

### DIFF
--- a/filter_parser.go
+++ b/filter_parser.go
@@ -157,7 +157,7 @@ func FilterParser() *Parser {
 	parser.DefineFunction("geo.distance", []int{2})
 	parser.DefineFunction("geo.intersects", []int{2})
 	parser.DefineFunction("geo.length", []int{1})
-	parser.DefineFunction("any", []int{1})
+	parser.DefineFunction("any", []int{0, 1}) // any function can take zero or one argument.
 	parser.DefineFunction("all", []int{1})
 
 	return parser

--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -465,7 +465,10 @@ func TestValidFilterSyntax(t *testing.T) {
 		"not (City in ('Dallas'))",
 		"not (City in ('Dallas', 'Houston'))",
 		"not (((City eq 'Dallas')))",
-		"Tags/any(var:var/Key eq 'Site' and var/Value eq 'London')",
+		"Tags/any()",                                                // The any operator without an argument returns true if the collection is not empty
+		"Tags/any(tag:tag eq 'London')",                             // 'Tags' is array of strings
+		"Tags/any(tag:tag eq 'London' or tag eq 'Berlin')",          // 'Tags' is array of strings
+		"Tags/any(var:var/Key eq 'Site' and var/Value eq 'London')", // 'Tags' is array of {"Key": "abc", "Value": "def"}
 		"Tags/ANY(var:var/Key eq 'Site' AND var/Value eq 'London')",
 		"Tags/any(var:var/Key eq 'Site' and var/Value eq 'London') and not (City in ('Dallas'))",
 		"Tags/all(var:var/Key eq 'Site' and var/Value eq 'London')",

--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -383,8 +383,10 @@ func TestValidFilterSyntax(t *testing.T) {
 		"startswith(CompanyName,'Alfr')",
 		"length(CompanyName) eq 19",
 		"indexof(CompanyName,'lfreds') eq 1",
-		"substring(CompanyName,1) eq 'lfreds Futterkiste'",
-		"substring(CompanyName,1,2) eq 'lf'", // substring with 3 arguments.
+		"substring(CompanyName,1) eq 'lfreds Futterkiste'", // substring() with 2 arguments.
+		"'lfreds Futterkiste' eq substring(CompanyName,1)", // Same as above, but order of operands is reversed.
+		"substring(CompanyName,1,2) eq 'lf'",               // substring() with 3 arguments.
+		"'lf' eq substring(CompanyName,1,2) ",              // Same as above, but order of operands is reversed.
 		"substringof('Alfreds', CompanyName) eq true",
 		"tolower(CompanyName) eq 'alfreds futterkiste'",
 		"toupper(CompanyName) eq 'ALFREDS FUTTERKISTE'",
@@ -426,6 +428,8 @@ func TestValidFilterSyntax(t *testing.T) {
 		"geo.intersects(Position,TargetArea)",
 		"GEO.INTERSECTS(Position,TargetArea)", // functions are case insensitive in ODATA 4.0.1
 		// Logical operators
+		"'Milk' eq 'Milk'",  // Compare two literals
+		"'Water' ne 'Milk'", // Compare two literals
 		"Name eq 'Milk'",
 		"Name EQ 'Milk'", // operators are case insensitive in ODATA 4.0.1
 		"Name ne 'Milk'",
@@ -434,6 +438,7 @@ func TestValidFilterSyntax(t *testing.T) {
 		"Name ge 'Milk'",
 		"Name lt 'Milk'",
 		"Name le 'Milk'",
+		"Name eq Name", // parameter equals to itself
 		"Name eq 'Milk' and Price lt 2.55",
 		"not endswith(Name,'ilk')",
 		"Name eq 'Milk' or Price lt 2.55",
@@ -490,12 +495,13 @@ func TestValidFilterSyntax(t *testing.T) {
 			t.Errorf("Error parsing query %s. Error: %s", input, err.Error())
 			return
 		}
+		fmt.Printf("Postfix queue: %v\n", output.String())
 		tree, err := GlobalFilterParser.PostfixToTree(output)
 		if err != nil {
 			t.Errorf("Error parsing query %s. Error: %s", input, err.Error())
 			return
 		} else if tree != nil {
-			//printTree(tree, 0)
+			printTree(tree, 0)
 		}
 	}
 }

--- a/parser.go
+++ b/parser.go
@@ -165,7 +165,8 @@ func (p *Parser) DefineOperator(token string, operands, assoc, precedence int, m
 	p.Operators[token] = &Operator{token, assoc, operands, precedence, multiValueOperand}
 }
 
-// Add a function to the language
+// DefineFunction adds a function to the language
+// params is the number of parameters this function accepts
 func (p *Parser) DefineFunction(token string, params []int) {
 	sort.Sort(sort.Reverse(sort.IntSlice(params)))
 	p.Functions[token] = &Function{token, params}
@@ -257,6 +258,7 @@ func (p *Parser) InfixToPostfix(tokens []*Token) (*tokenQueue, error) {
 			//   These precedence tokens are removed while parsing the OData query.
 			// - As a grouping operator for multi-value sets, such as "City in ('San Jose', 'Chicago', 'Dallas')"
 			//   The grouping tokens are retained while parsing the OData query.
+			// - To specify function parameters
 			if p.isGroupingOperator(&stack, token) {
 				// The '(' token is used as a grouping operator.
 				queue.Enqueue(token)
@@ -490,13 +492,13 @@ func (q *tokenQueue) Empty() bool {
 }
 
 func (q *tokenQueue) String() string {
-	result := ""
+	var sb strings.Builder
 	node := q.Head
 	for node != nil {
-		result += node.Token.Value
+		sb.WriteString(fmt.Sprintf("[%s]", node.Token.Value))
 		node = node.Next
 	}
-	return result
+	return sb.String()
 }
 
 type nodeStack struct {


### PR DESCRIPTION
Add unit tests for the following scenarios:

1. any() function without arguments
1. any() function when the array contains a list of primitive types, such as string
1. Filter expression when the second operand contains the **substring** function:
    `'lfreds Futterkiste' eq substring(CompanyName,1)`
1. Comparing literals: 'Milk' eq 'Milk'
1. Comparing parameters