### PR TITLE
A query parameter with a single argument causes error

### DIFF
--- a/filter_parser.go
+++ b/filter_parser.go
@@ -28,12 +28,15 @@ const (
 var GlobalFilterTokenizer = FilterTokenizer()
 var GlobalFilterParser = FilterParser()
 
-// Convert an input string from the $filter part of the URL into a parse
+// ParseFilterString converts an input string from the $filter part of the URL into a parse
 // tree that can be used by providers to create a response.
 func ParseFilterString(filter string) (*GoDataFilterQuery, error) {
 	tokens, err := GlobalFilterTokenizer.Tokenize(filter)
 	if err != nil {
 		return nil, err
+	}
+	if len(tokens) == 1 && tokens[0].Type != FilterTokenBoolean {
+		return nil, BadRequestError("Value must be a boolean expression")
 	}
 	// TODO: can we do this in one fell swoop?
 	postfix, err := GlobalFilterParser.InfixToPostfix(tokens)

--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -537,21 +537,13 @@ func TestInvalidFilterSyntax(t *testing.T) {
 		//"contains(Name, 'a', 'b', 'c', 'd')", // Too many function arguments
 	}
 	for _, input := range queries {
-		tokens, err := GlobalFilterTokenizer.Tokenize(input)
+		q, err := ParseFilterString(input)
 		if err == nil {
-			var output *tokenQueue
-			output, err = GlobalFilterParser.InfixToPostfix(tokens)
-			if err == nil {
-				var tree *ParseNode
-				tree, err = GlobalFilterParser.PostfixToTree(output)
-				if err == nil {
-					// The parser has incorrectly determined the syntax is valid.
-					printTree(tree, 0)
-				}
-			}
+			// The parser has incorrectly determined the syntax is valid.
+			printTree(q.Tree, 0)
 		}
 		if err == nil {
-			t.Errorf("The query '%s' is not valid ODATA syntax. The ODATA parser should return an error", input)
+			t.Errorf("The query '$filter=%s' is not valid ODATA syntax. The ODATA parser should return an error", input)
 			return
 		}
 	}

--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -500,6 +500,7 @@ func TestValidFilterSyntax(t *testing.T) {
 // The URLs below are not valid ODATA syntax, the parser should return an error.
 func TestInvalidFilterSyntax(t *testing.T) {
 	queries := []string{
+		//"City",                                 // Just a single literal
 		"",                                     // Nothing
 		"eq",                                   // Just a single logical operator
 		"and",                                  // Just a single logical operator
@@ -507,7 +508,6 @@ func TestInvalidFilterSyntax(t *testing.T) {
 		"add ",                                 // Just a single arithmetic operator
 		"add 2",                                // Missing operands
 		"add 2 3",                              // Missing operands
-		"City",                                 // Just a single literal
 		"City City City City",                  // Sequence of literals
 		"City eq",                              // Missing operand
 		"City eq (",                            // Wrong operand

--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -380,6 +380,13 @@ func TestValidFilterSyntax(t *testing.T) {
 		// Bolean values
 		"true",
 		"false",
+		"(true)",
+		"((true))",
+		"((true)) or false",
+		"not true",
+		"not false",
+		"not (not true)",
+		//"not not true", // TODO: I think this should work. 'not not true' is true
 		// String functions
 		"contains(CompanyName,'freds')",
 		"endswith(CompanyName,'Futterkiste')",
@@ -493,11 +500,18 @@ func TestValidFilterSyntax(t *testing.T) {
 // The URLs below are not valid ODATA syntax, the parser should return an error.
 func TestInvalidFilterSyntax(t *testing.T) {
 	queries := []string{
+		//"()", // TODO: this should not be valid, it's not a boolean expression
+		"(",
+		"((((",
+		")",
+		"12345",                                // Number 12345 is not a boolean expression
+		"0",                                    // Number 0 is not a boolean expression
+		"'123'",                                // String '123' is not a boolean expression
 		"TRUE",                                 // Should be 'true' lowercase
 		"FALSE",                                // Should be 'false' lowercase
 		"yes",                                  // yes is not a boolean expression
 		"no",                                   // yes is not a boolean expression
-		"",                                     // Nothing
+		"",                                     // Empty string.
 		"eq",                                   // Just a single logical operator
 		"and",                                  // Just a single logical operator
 		"add",                                  // Just a single arithmetic operator

--- a/parser.go
+++ b/parser.go
@@ -111,7 +111,7 @@ func (t *Tokenizer) TokenizeBytes(target []byte) ([]*Token, error) {
 		return result, BadRequestError("No matching token for " + string(target))
 	}
 	if len(result) < 1 {
-		return result, BadRequestError("Missing parameter")
+		return result, BadRequestError("Empty query parameter")
 	}
 	return result, nil
 }

--- a/parser.go
+++ b/parser.go
@@ -110,8 +110,8 @@ func (t *Tokenizer) TokenizeBytes(target []byte) ([]*Token, error) {
 	if len(target) > 0 && !match {
 		return result, BadRequestError("No matching token for " + string(target))
 	}
-	if len(result) <= 1 {
-		return result, BadRequestError("Missing parameter for " + string(target))
+	if len(result) < 1 {
+		return result, BadRequestError("Missing parameter")
 	}
 	return result, nil
 }

--- a/url_parser_test.go
+++ b/url_parser_test.go
@@ -194,4 +194,28 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		return
 	}
 
+	testUrl = "Employees(1)/Sales.Manager?$select=LastName&$expand=Address"
+	parsedUrl, err = url.Parse(testUrl)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	_, err = ParseRequest(parsedUrl.Path, parsedUrl.Query(), false)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	testUrl = "Employees(1)/Sales.Manager?$select=FirstName,LastName&$expand=Address"
+	parsedUrl, err = url.Parse(testUrl)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	_, err = ParseRequest(parsedUrl.Path, parsedUrl.Query(), false)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
 }


### PR DESCRIPTION
1. Add unit tests for $expand with a single parameter
1. Add unit tests for false, FALSE, true, TRUE, YES, yes.