### PR TITLE
Duration type, variadic functions, IN operator, ANY operator

### DIFF
--- a/expand_parser.go
+++ b/expand_parser.go
@@ -162,7 +162,7 @@ func ParseExpandOption(queue *tokenQueue, item *ExpandItem) error {
 		return BadRequestError("Invalid expand clause.")
 	}
 	queue.Dequeue() // drop the '=' from the front of the queue
-	body := queue.String()
+	body := queue.GetValue()
 
 	if head == "$filter" {
 		filter, err := ParseFilterString(body)

--- a/expand_parser_test.go
+++ b/expand_parser_test.go
@@ -72,13 +72,13 @@ func TestExpandNestedCommas(t *testing.T) {
 
 	if output.ExpandItems[0].Select.SelectItems[0].Segments[0].Value != "FirstName" {
 		actual := output.ExpandItems[0].Select.SelectItems[0].Segments[0]
-		t.Error("First select segment is '" + actual.Value + "' not 'FirstName'")
+		t.Error("First select segment is '" + actual.Value + "', expected 'FirstName'")
 		return
 	}
 
 	if output.ExpandItems[0].Select.SelectItems[1].Segments[0].Value != "LastName" {
 		actual := output.ExpandItems[0].Select.SelectItems[1].Segments[0]
-		t.Error("First select segment is '" + actual.Value + "' not 'LastName'")
+		t.Error("First select segment is '" + actual.Value + "', expected 'LastName'")
 		return
 	}
 

--- a/filter_parser.go
+++ b/filter_parser.go
@@ -118,27 +118,29 @@ func FilterTokenizer() *Tokenizer {
 
 func FilterParser() *Parser {
 	parser := EmptyParser()
-	parser.DefineOperator("/", 2, OpAssociationLeft, 9, false)
-	parser.DefineOperator("has", 2, OpAssociationLeft, 9, false)
-	parser.DefineOperator("-", 1, OpAssociationNone, 8, false)
-	parser.DefineOperator("not", 1, OpAssociationLeft, 8, false)
-	parser.DefineOperator("cast", 2, OpAssociationNone, 8, false)
-	parser.DefineOperator("mul", 2, OpAssociationNone, 7, false)
-	parser.DefineOperator("div", 2, OpAssociationNone, 7, false)   // Division
-	parser.DefineOperator("divby", 2, OpAssociationNone, 7, false) // Decimal Division
-	parser.DefineOperator("mod", 2, OpAssociationNone, 7, false)
-	parser.DefineOperator("add", 2, OpAssociationNone, 6, false)
-	parser.DefineOperator("sub", 2, OpAssociationNone, 6, false)
-	parser.DefineOperator("gt", 2, OpAssociationLeft, 5, false)
-	parser.DefineOperator("ge", 2, OpAssociationLeft, 5, false)
-	parser.DefineOperator("lt", 2, OpAssociationLeft, 5, false)
-	parser.DefineOperator("le", 2, OpAssociationLeft, 5, false)
-	parser.DefineOperator("eq", 2, OpAssociationLeft, 4, false)
-	parser.DefineOperator("ne", 2, OpAssociationLeft, 4, false)
-	parser.DefineOperator("in", 2, OpAssociationLeft, 4, true) // 'in' operator takes a literal list.
-	parser.DefineOperator("and", 2, OpAssociationLeft, 3, false)
-	parser.DefineOperator("or", 2, OpAssociationLeft, 2, false)
-	parser.DefineOperator(":", 2, OpAssociationLeft, 1, false)
+	parser.DefineOperator("/", 2, OpAssociationLeft, 9)
+	parser.DefineOperator("has", 2, OpAssociationLeft, 9)
+	// 'in' operator takes a literal list.
+	// City in ('Seattle') needs to be interpreted as a list expression, not a paren expression.
+	parser.DefineOperator("in", 2, OpAssociationLeft, 9).SetPreferListExpr(true)
+	parser.DefineOperator("-", 1, OpAssociationNone, 8)
+	parser.DefineOperator("not", 1, OpAssociationLeft, 8)
+	parser.DefineOperator("cast", 2, OpAssociationNone, 8)
+	parser.DefineOperator("mul", 2, OpAssociationNone, 7)
+	parser.DefineOperator("div", 2, OpAssociationNone, 7)   // Division
+	parser.DefineOperator("divby", 2, OpAssociationNone, 7) // Decimal Division
+	parser.DefineOperator("mod", 2, OpAssociationNone, 7)
+	parser.DefineOperator("add", 2, OpAssociationNone, 6)
+	parser.DefineOperator("sub", 2, OpAssociationNone, 6)
+	parser.DefineOperator("gt", 2, OpAssociationLeft, 5)
+	parser.DefineOperator("ge", 2, OpAssociationLeft, 5)
+	parser.DefineOperator("lt", 2, OpAssociationLeft, 5)
+	parser.DefineOperator("le", 2, OpAssociationLeft, 5)
+	parser.DefineOperator("eq", 2, OpAssociationLeft, 4)
+	parser.DefineOperator("ne", 2, OpAssociationLeft, 4)
+	parser.DefineOperator("and", 2, OpAssociationLeft, 3)
+	parser.DefineOperator("or", 2, OpAssociationLeft, 2)
+	parser.DefineOperator(":", 2, OpAssociationLeft, 1)
 	parser.DefineFunction("contains", []int{2})
 	parser.DefineFunction("endswith", []int{2})
 	parser.DefineFunction("startswith", []int{2})

--- a/filter_parser.go
+++ b/filter_parser.go
@@ -53,7 +53,9 @@ func ParseFilterString(filter string) (*GoDataFilterQuery, error) {
 }
 
 // FilterTokenDurationRe is a regex for a token of type duration.
-const FilterTokenDurationRe = `^(duration)?'-?P((([0-9]+Y([0-9]+M)?([0-9]+D)?|([0-9]+M)([0-9]+D)?|([0-9]+D))(T(([0-9]+H)([0-9]+M)?([0-9]+(\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\.[0-9]+)?S)?|([0-9]+(\.[0-9]+)?S)))?)|(T(([0-9]+H)([0-9]+M)?([0-9]+(\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\.[0-9]+)?S)?|([0-9]+(\.[0-9]+)?S))))'`
+// The token value is set to the ISO 8601 string inside the single quotes
+// For example, if the input data is duration'PT2H', then the token value is set to PT2H without quotes.
+const FilterTokenDurationRe = `^(duration)?'(?P<subtoken>-?P((([0-9]+Y([0-9]+M)?([0-9]+D)?|([0-9]+M)([0-9]+D)?|([0-9]+D))(T(([0-9]+H)([0-9]+M)?([0-9]+(\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\.[0-9]+)?S)?|([0-9]+(\.[0-9]+)?S)))?)|(T(([0-9]+H)([0-9]+M)?([0-9]+(\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\.[0-9]+)?S)?|([0-9]+(\.[0-9]+)?S)))))'`
 
 // FilterTokenizer creates a tokenizer capable of tokenizing filter statements
 // 4.01 Services MUST support case-insensitive operator names.

--- a/filter_parser.go
+++ b/filter_parser.go
@@ -175,7 +175,7 @@ func FilterParser() *Parser {
 	parser.DefineFunction("geo.distance", []int{2})
 	parser.DefineFunction("geo.intersects", []int{2})
 	parser.DefineFunction("geo.length", []int{1})
-	parser.DefineFunction("any", []int{1})
+	parser.DefineFunction("any", []int{0, 1}) // 'any' can take either zero or one argument.
 	parser.DefineFunction("all", []int{1})
 
 	return parser

--- a/filter_parser.go
+++ b/filter_parser.go
@@ -52,6 +52,9 @@ func ParseFilterString(filter string) (*GoDataFilterQuery, error) {
 	return &GoDataFilterQuery{tree, filter}, nil
 }
 
+// FilterTokenDurationRe is a regex for a token of type duration.
+const FilterTokenDurationRe = `^(duration)?'-?P((([0-9]+Y([0-9]+M)?([0-9]+D)?|([0-9]+M)([0-9]+D)?|([0-9]+D))(T(([0-9]+H)([0-9]+M)?([0-9]+(\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\.[0-9]+)?S)?|([0-9]+(\.[0-9]+)?S)))?)|(T(([0-9]+H)([0-9]+M)?([0-9]+(\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\.[0-9]+)?S)?|([0-9]+(\.[0-9]+)?S))))'`
+
 // FilterTokenizer creates a tokenizer capable of tokenizing filter statements
 // 4.01 Services MUST support case-insensitive operator names.
 // See https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#_Toc31360955
@@ -64,7 +67,7 @@ func FilterTokenizer() *Tokenizer {
 	// Duration literals in OData 4.0 required prefixing with “duration”.
 	// In OData 4.01, services MUST support duration and enumeration literals with or without the type prefix.
 	// OData clients that want to operate across OData 4.0 and OData 4.01 services should always include the prefix for duration and enumeration types.
-	t.Add(`^(duration)?'-?P((([0-9]+Y([0-9]+M)?([0-9]+D)?|([0-9]+M)([0-9]+D)?|([0-9]+D))(T(([0-9]+H)([0-9]+M)?([0-9]+(\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\.[0-9]+)?S)?|([0-9]+(\.[0-9]+)?S)))?)|(T(([0-9]+H)([0-9]+M)?([0-9]+(\.[0-9]+)?S)?|([0-9]+M)([0-9]+(\.[0-9]+)?S)?|([0-9]+(\.[0-9]+)?S))))'`, FilterTokenDuration)
+	t.Add(FilterTokenDurationRe, FilterTokenDuration)
 	t.Add("^[0-9]{4,4}-[0-9]{2,2}-[0-9]{2,2}T[0-9]{2,2}:[0-9]{2,2}(:[0-9]{2,2}(.[0-9]+)?)?(Z|[+-][0-9]{2,2}:[0-9]{2,2})", FilterTokenDateTime)
 	t.Add("^-?[0-9]{4,4}-[0-9]{2,2}-[0-9]{2,2}", FilterTokenDate)
 	t.Add("^[0-9]{2,2}:[0-9]{2,2}(:[0-9]{2,2}(.[0-9]+)?)?", FilterTokenTime)

--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -351,7 +351,7 @@ func TestFilterInOperator(t *testing.T) {
 		&Token{Value: "'Atlanta'", Type: FilterTokenString},
 		&Token{Value: "'Paris'", Type: FilterTokenString},
 		&Token{Value: "3", Type: TokenTypeArgCount},
-		&Token{Value: "list", Type: TokenTypeListExpr},
+		&Token{Value: TokenListExpr, Type: TokenTypeListExpr},
 		&Token{Value: "in", Type: FilterTokenLogical},
 	}
 	result, err = CompareQueue(expect, postfix)
@@ -367,7 +367,7 @@ func TestFilterInOperator(t *testing.T) {
 	var treeExpect []expectedParseNode = []expectedParseNode{
 		{"in", 0},
 		{"City", 1},
-		{"list", 1},
+		{TokenListExpr, 1},
 		{"'Seattle'", 2},
 		{"'Atlanta'", 2},
 		{"'Paris'", 2},
@@ -409,7 +409,7 @@ func TestFilterInOperatorSingleValue(t *testing.T) {
 		&Token{Value: "City", Type: FilterTokenLiteral},
 		&Token{Value: "'Seattle'", Type: FilterTokenString},
 		&Token{Value: "1", Type: TokenTypeArgCount},
-		&Token{Value: "list", Type: TokenTypeListExpr},
+		&Token{Value: TokenListExpr, Type: TokenTypeListExpr},
 		&Token{Value: "in", Type: FilterTokenLogical},
 	}
 	result, err = CompareQueue(expect, postfix)
@@ -425,7 +425,7 @@ func TestFilterInOperatorSingleValue(t *testing.T) {
 	var treeExpect []expectedParseNode = []expectedParseNode{
 		{"in", 0},
 		{"City", 1},
-		{"list", 1},
+		{TokenListExpr, 1},
 		{"'Seattle'", 2},
 	}
 	pos := 0
@@ -463,7 +463,7 @@ func TestFilterInOperatorEmptyList(t *testing.T) {
 	expect = []*Token{
 		&Token{Value: "City", Type: FilterTokenLiteral},
 		&Token{Value: "0", Type: TokenTypeArgCount},
-		&Token{Value: "list", Type: TokenTypeListExpr},
+		&Token{Value: TokenListExpr, Type: TokenTypeListExpr},
 		&Token{Value: "in", Type: FilterTokenLogical},
 	}
 	result, err = CompareQueue(expect, postfix)
@@ -479,7 +479,7 @@ func TestFilterInOperatorEmptyList(t *testing.T) {
 	var treeExpect []expectedParseNode = []expectedParseNode{
 		{"in", 0},
 		{"City", 1},
-		{"list", 1},
+		{TokenListExpr, 1},
 	}
 	pos := 0
 	err = CompareTree(tree, treeExpect, &pos, 0)
@@ -544,25 +544,25 @@ func TestFilterInOperatorBothSides(t *testing.T) {
 		&Token{Value: "1", Type: FilterTokenInteger},
 		&Token{Value: "2", Type: FilterTokenInteger},
 		&Token{Value: "2", Type: TokenTypeArgCount},
-		&Token{Value: "list", Type: TokenTypeListExpr},
+		&Token{Value: TokenListExpr, Type: TokenTypeListExpr},
 
 		&Token{Value: "'ab'", Type: FilterTokenString},
 		&Token{Value: "'cd'", Type: FilterTokenString},
 		&Token{Value: "2", Type: TokenTypeArgCount},
-		&Token{Value: "list", Type: TokenTypeListExpr},
+		&Token{Value: TokenListExpr, Type: TokenTypeListExpr},
 
 		&Token{Value: "1", Type: FilterTokenInteger},
 		&Token{Value: "2", Type: FilterTokenInteger},
 		&Token{Value: "2", Type: TokenTypeArgCount},
-		&Token{Value: "list", Type: TokenTypeListExpr},
+		&Token{Value: TokenListExpr, Type: TokenTypeListExpr},
 
 		&Token{Value: "'abc'", Type: FilterTokenString},
 		&Token{Value: "'def'", Type: FilterTokenString},
 		&Token{Value: "2", Type: TokenTypeArgCount},
-		&Token{Value: "list", Type: TokenTypeListExpr},
+		&Token{Value: TokenListExpr, Type: TokenTypeListExpr},
 
 		&Token{Value: "3", Type: TokenTypeArgCount},
-		&Token{Value: "list", Type: TokenTypeListExpr},
+		&Token{Value: TokenListExpr, Type: TokenTypeListExpr},
 
 		&Token{Value: "in", Type: FilterTokenLogical},
 	}
@@ -579,18 +579,18 @@ func TestFilterInOperatorBothSides(t *testing.T) {
 
 	var treeExpect []expectedParseNode = []expectedParseNode{
 		{"in", 0},
-		{"list", 1},
+		{TokenListExpr, 1},
 		{"1", 2},
 		{"2", 2},
 		//  ('ab', 'cd'), (1, 2), ('abc', 'def')
-		{"list", 1},
-		{"list", 2},
+		{TokenListExpr, 1},
+		{TokenListExpr, 2},
 		{"'ab'", 3},
 		{"'cd'", 3},
-		{"list", 2},
+		{TokenListExpr, 2},
 		{"1", 3},
 		{"2", 3},
-		{"list", 2},
+		{TokenListExpr, 2},
 		{"'abc'", 3},
 		{"'def'", 3},
 	}
@@ -644,7 +644,7 @@ func TestFilterInOperatorWithFunc(t *testing.T) {
 	var expect []expectedParseNode = []expectedParseNode{
 		{"in", 0},
 		{"City", 1},
-		{"list", 1},
+		{TokenListExpr, 1},
 		{"'Seattle'", 2},
 		{"concat", 2},
 		{"'San'", 3},
@@ -706,7 +706,7 @@ func TestFilterNotInListExpr(t *testing.T) {
 			{"not", 0},
 			{"in", 1},
 			{"City", 2},
-			{"list", 2},
+			{TokenListExpr, 2},
 			{"'Seattle'", 3},
 			{"'Atlanta'", 3},
 		}
@@ -1220,7 +1220,7 @@ func TestFilterIn(t *testing.T) {
 			t.Errorf("Unexpected operand for the 'in' operator. Expected 'Site', got %s",
 				tree.Children[0].Children[1].Children[0].Token.Value)
 		}
-		if tree.Children[0].Children[1].Children[1].Token.Value != "list" {
+		if tree.Children[0].Children[1].Children[1].Token.Value != TokenListExpr {
 			t.Errorf("Unexpected operand for the 'in' operator. Expected 'list', got %s",
 				tree.Children[0].Children[1].Children[1].Token.Value)
 		}

--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -159,7 +159,8 @@ func TestFilterDurationWithType(t *testing.T) {
 	expect := []*Token{
 		&Token{Value: "Task", Type: FilterTokenLiteral},
 		&Token{Value: "eq", Type: FilterTokenLogical},
-		&Token{Value: "duration'P12DT23H59M59.999999999999S'", Type: FilterTokenDuration},
+		// Note the duration token is extracted.
+		&Token{Value: "P12DT23H59M59.999999999999S", Type: FilterTokenDuration},
 	}
 	output, err := tokenizer.Tokenize(input)
 	if err != nil {
@@ -179,7 +180,7 @@ func TestFilterDurationWithoutType(t *testing.T) {
 	expect := []*Token{
 		&Token{Value: "Task", Type: FilterTokenLiteral},
 		&Token{Value: "eq", Type: FilterTokenLogical},
-		&Token{Value: "'P12DT23H59M59.999999999999S'", Type: FilterTokenDuration},
+		&Token{Value: "P12DT23H59M59.999999999999S", Type: FilterTokenDuration},
 	}
 	output, err := tokenizer.Tokenize(input)
 	if err != nil {

--- a/parser.go
+++ b/parser.go
@@ -14,18 +14,18 @@ const (
 	OpAssociationNone
 )
 
-// TokenTypeWall is a delimiter token for variadic functions and operators
-const TokenTypeWall int = -1
-const TokenTypeArgCount int = -2
-const TokenTypeListExpr int = -3
+// TokenTypeArgCount is used to specify the number of arguments of a function or listExpr
+// This is used to handle variadic functions and listExpr.
+const TokenTypeArgCount int = -1
 
-/*
-const (
-	NodeTypeLiteral int = iota
-	NodeTypeOp
-	NodeTypeFunc
-)
-*/
+// TokenTypeListExpr represents a parent node for a variadic listExpr.
+// "list"
+//   "item1"
+//   "item2"
+//   ...
+const TokenTypeListExpr int = -2
+
+const TokenListExpr = "list"
 
 type Tokenizer struct {
 	TokenMatchers  []*TokenMatcher
@@ -378,7 +378,7 @@ func (p *Parser) InfixToPostfix(tokens []*Token) (*tokenQueue, error) {
 				// Enqueue a 'list' token if we are processing a ListExpr.
 				if !isFunc {
 					queue.Enqueue(&Token{
-						Value: "list",
+						Value: TokenListExpr,
 						Type:  TokenTypeListExpr,
 					})
 				}

--- a/parser.go
+++ b/parser.go
@@ -97,12 +97,22 @@ func (t *Tokenizer) TokenizeBytes(target []byte) ([]*Token, error) {
 			// If the input data is `Name eq 'Bob'`, the token is correctly set to 'eq' and
 			// the space after eq is not consumed, because the space character itself is supposed
 			// to be the next token.
+			//
+			// If Token.Value needs to be a sub-regex but the entire token needs to be consumed,
+			// use 'subtoken'
+			//    ^(duration)?'(?P<subtoken>[0-9])'
+			l := 0
 			if idx := m.Re.SubexpIndex("token"); idx > 0 {
 				token = tokens[idx]
+				l = len(token)
+			} else if idx := m.Re.SubexpIndex("subtoken"); idx > 0 {
+				token = tokens[idx]
+				l = len(tokens[0])
 			} else {
 				token = tokens[0]
+				l = len(token)
 			}
-			target = target[len(token):] // remove the token from the input
+			target = target[l:] // remove the token from the input
 			if !ignore {
 				if m.CaseInsentitive {
 					// In ODATA 4.0.1, operators and functions are case insensitive.

--- a/parser.go
+++ b/parser.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -13,11 +14,18 @@ const (
 	OpAssociationNone
 )
 
+// TokenTypeWall is a delimiter token for variadic functions and operators
+const TokenTypeWall int = -1
+const TokenTypeArgCount int = -2
+const TokenTypeListExpr int = -3
+
+/*
 const (
 	NodeTypeLiteral int = iota
 	NodeTypeOp
 	NodeTypeFunc
 )
+*/
 
 type Tokenizer struct {
 	TokenMatchers  []*TokenMatcher
@@ -36,7 +44,7 @@ type Token struct {
 	Type  int
 	// Holds information about the semantic meaning of this token taken from the
 	// context of the GoDataService.
-	SemanticType      int
+	SemanticType      SemanticType
 	SemanticReference interface{}
 }
 
@@ -135,10 +143,19 @@ type Operator struct {
 	Operands int
 	// Rank of precedence
 	Precedence int
-	// Specifies whether the right-side operand is single value (by default) or multi-value.
-	// For example, "City in ('San Jose', 'Chicago', 'Dallas')"
-	// For left-side operand, the parser algorithm needs to change to support backtracking.
-	MultiValueOperand bool
+	// Determine if the operands should be interpreted as a ListExpr or parenExpr according
+	// to ODATA ABNF grammar.
+	// This is only used when a listExpr has zero or one items.
+	// When a listExpr has 2 or more items, there is no ambiguity between listExpr and parenExpr.
+	// For example:
+	//    2 + (3) ==> the right operand is a parenExpr
+	//    City IN ('Seattle', 'Atlanta') ==> the right operand is unambiguously a listExpr
+	//    City IN ('Seattle') ==> the right operand should be a listExpr
+	PreferListExpr bool
+}
+
+func (o *Operator) SetPreferListExpr(v bool) {
+	o.PreferListExpr = v
 }
 
 type Function struct {
@@ -178,32 +195,23 @@ func EmptyParser() *Parser {
 	return &Parser{make(map[string]*Operator, 0), make(map[string]*Function)}
 }
 
-// Add an operator to the language. Provide the token, the expected number of arguments,
+// DefineOperator adds an operator to the language. Provide the token, the expected number of arguments,
 // whether the operator is left, right, or not associative, and a precedence.
-// The operandsCardinality specifies whether the operands are single-value or multi-value, which must
-// be a comma-separated list enclosed in parenthesis.
-func (p *Parser) DefineOperator(token string, operands, assoc, precedence int, multiValueOperand bool) {
-	p.Operators[token] = &Operator{token, assoc, operands, precedence, multiValueOperand}
+func (p *Parser) DefineOperator(token string, operands, assoc, precedence int) *Operator {
+	op := &Operator{
+		Token:       token,
+		Association: assoc,
+		Operands:    operands,
+		Precedence:  precedence,
+	}
+	p.Operators[token] = op
+	return op
 }
 
-// Add a function to the language
+// DefineFunction adds a function to the language
 func (p *Parser) DefineFunction(token string, params []int) {
 	sort.Sort(sort.Reverse(sort.IntSlice(params)))
 	p.Functions[token] = &Function{token, params}
-}
-
-// isGroupingOperator returns true if the specified token uses
-// parenthesis as multi-value grouping delimiters.
-func (p *Parser) isGroupingOperator(stack *tokenStack, token *Token) bool {
-	if !stack.Empty() {
-		if o1, ok := p.Operators[stack.Peek().Value]; ok {
-			if o1.MultiValueOperand {
-				// The '(' token is used as a grouping operator.
-				return true
-			}
-		}
-	}
-	return false
 }
 
 // IsLiteral returns true if the specified token is considered a literal for this parser.
@@ -221,8 +229,14 @@ func (p *Parser) IsLiteral(token *Token) bool {
 }
 
 // InfixToPostfix parses the input string of tokens using the given definitions of operators
-// and functions. (Everything else is assumed to be a literal.) Uses the
-// Shunting-Yard algorithm.
+// and functions.
+// Everything else is assumed to be a literal.
+// Uses the Shunting-Yard algorithm.
+//
+// Infix notation for variadic functions and operators: f ( a, b, c, d )
+// Postfix notation with wall notation:                 | a b c d f
+// Postfix notation with count notation:                a b c d 4 f
+//
 func (p *Parser) InfixToPostfix(tokens []*Token) (*tokenQueue, error) {
 	queue := tokenQueue{} // output queue in postfix
 	stack := tokenStack{} // Operator stack
@@ -246,16 +260,27 @@ func (p *Parser) InfixToPostfix(tokens []*Token) (*tokenQueue, error) {
 				// A function token must be followed by open parenthesis token.
 				return nil, BadRequestError(fmt.Sprintf("Function '%s' must be followed by '('", token.Value))
 			}
+			stack.incrementListArgCount()
 			// push functions onto the stack
 			stack.Push(token)
 		} else if token.Value == "," {
-			// function parameter separator, pop off stack until we see a "("
+			// Comma may be used as:
+			// 1. Separator of function parameters,
+			// 2. Separator for listExpr such as "City IN ('Seattle', 'San Francisco')"
+			//
+			// Pop off stack until we see a "("
 			for !stack.Empty() && stack.Peek().Value != "(" {
+				// This happens when the previous function argument is an expression composed
+				// of multiple tokens, as opposed to a single token. For example:
+				//     max(sin( 5 mul pi ) add 3, sin( 5 ))
 				queue.Enqueue(stack.Pop())
 			}
-			// there was an error parsing
 			if stack.Empty() {
+				// there was an error parsing. The top of the stack must be open parenthesis
 				return nil, BadRequestError("Parse error")
+			}
+			if stack.Peek().Value != "(" {
+				panic("unexpected token")
 			}
 		} else if o1, ok := p.Operators[token.Value]; ok {
 			// push operators onto stack according to precedence
@@ -274,62 +299,97 @@ func (p *Parser) InfixToPostfix(tokens []*Token) (*tokenQueue, error) {
 			stack.Push(token)
 		} else if token.Value == "(" {
 			// In OData, the parenthesis tokens can be used:
-			// - To set explicit precedence order, such as "(a + 2) x b"
+			// - As a parenExpr to set explicit precedence order, such as "(a + 2) x b"
 			//   These precedence tokens are removed while parsing the OData query.
-			// - As a grouping operator for multi-value sets, such as "City in ('San Jose', 'Chicago', 'Dallas')"
-			//   The grouping tokens are retained while parsing the OData query.
-			if p.isGroupingOperator(&stack, token) {
-				// The '(' token is used as a grouping operator.
-				queue.Enqueue(token)
-			} else {
-				// The '(' token is used to set explicit precedence order. Do not enqueue
-			}
-			// push open parens onto the stack
+			// - As a listExpr for multi-value sets, such as "City in ('San Jose', 'Chicago', 'Dallas')"
+			//   The list tokens are retained while parsing the OData query.
+			//   ABNF grammar:
+			//   listExpr  = OPEN BWS commonExpr BWS *( COMMA BWS commonExpr BWS ) CLOSE
+			stack.incrementListArgCount()
+			// Push open parens onto the stack
 			stack.Push(token)
 		} else if token.Value == ")" {
 			// if we find a close paren, pop things off the stack
-			multiValueOperand := false
 			for !stack.Empty() {
 				if stack.Peek().Value == "(" {
-					// Pop the stack so we can see the second element in the stack.
-					t := stack.Pop()
-					if !stack.Empty() && p.isGroupingOperator(&stack, stack.Peek()) {
-						// The ')' token is used as the closing grouping operator.
-						queue.Enqueue(token)       // The ')' closing parenthesis
-						queue.Enqueue(stack.Pop()) // The operator that takes a multi-value operand.
-						multiValueOperand = true
-						// Continue dequeuing until we find a precedence delimiter
-					} else {
-						// In this case, '(' is a precedence token, we stop popping the operators
-						// from the stack, and we need to re-add the last token back on the stack,
-						// which was done to inspect whether the second operator in the stack takes
-						// a multi-value operand.
-						stack.Push(t)
-						break
-					}
+					break
 				} else {
 					queue.Enqueue(stack.Pop())
 				}
 			}
-			// there was an error parsing
 			if stack.Empty() {
-				if !multiValueOperand {
-					return nil, BadRequestError("Parse error. Mismatched parenthesis.")
+				// there was an error parsing
+				return nil, BadRequestError("Parse error. Mismatched parenthesis.")
+			}
+			// Get the argument count associated with the open paren.
+			// Example: (a, b, c) is a listExpr with three arguments.
+			argCount := stack.getArgCount()
+			// pop off open paren
+			stack.Pop()
+
+			// Determine if the parenthesis delimiters are:
+			// - A listExpr, possibly an empty list or single element.
+			//   Note a listExpr may be on the left-side or right-side of operators,
+			//   or it may be a list of function arguments.
+			// - A parenExpr, which is used as a precedence delimiter.
+			//
+			// (1, 2, 3) is a listExpr, there is no ambiguity.
+			// (1) matches both listExpr or parenExpr.
+			// parenExpr takes precedence over listExpr.
+			//
+			// For example:
+			//   1 IN (1, 2)  ==> parenthesis is used to create a list of two elements.
+			//   (1) + (2)    ==> parenthesis is a precedence delimiter, i.e. parenExpr.
+			var isFunc, isListExpr bool
+			if !stack.Empty() {
+				_, isFunc = p.Functions[stack.Peek().Value]
+			}
+			switch {
+			case isFunc:
+				isListExpr = true
+			case argCount <= 1:
+				// When a listExpr contains a single item, it is ambiguous whether it is a listExpr or parenExpr.
+				if !stack.Empty() {
+					if o1, ok := p.Operators[stack.Peek().Value]; ok {
+						if o1.PreferListExpr {
+							// The expression is the right operand of an operator that has a preference for listExpr vs parenExpr.
+							isListExpr = true
+						}
+					}
 				}
-			} else {
-				if !multiValueOperand {
-					// pop off open paren
-					stack.Pop()
+				if !isListExpr && len(tokens) > 0 {
+					if o1, ok := p.Operators[tokens[0].Value]; ok {
+						// The expression is the left operand of an operator that has a preference for listExpr vs parenExpr.
+						if o1.PreferListExpr {
+							isListExpr = true
+						}
+					}
+				}
+			case argCount > 1:
+				isListExpr = true
+			}
+			if isListExpr {
+				// The open parenthesis was a delimiter for a listExpr.
+				// Add a token indicating the number of arguments in the list.
+				queue.Enqueue(&Token{
+					Value: strconv.Itoa(argCount),
+					Type:  TokenTypeArgCount,
+				})
+				// Enqueue a 'list' token if we are processing a ListExpr.
+				if !isFunc {
+					queue.Enqueue(&Token{
+						Value: "list",
+						Type:  TokenTypeListExpr,
+					})
 				}
 			}
-			// if next token is a function, move it to the queue
-			if !stack.Empty() {
-				if _, ok := p.Functions[stack.Peek().Value]; ok {
-					queue.Enqueue(stack.Pop())
-				}
+			// if next token is a function or multi-value operator, move it to the queue
+			if isFunc {
+				queue.Enqueue(stack.Pop())
 			}
 		} else {
 			// Token is a literal -- put it in the queue
+			stack.incrementListArgCount()
 			queue.Enqueue(token)
 		}
 	}
@@ -344,7 +404,7 @@ func (p *Parser) InfixToPostfix(tokens []*Token) (*tokenQueue, error) {
 	return &queue, nil
 }
 
-// Convert a Postfix token queue to a parse tree
+// PostfixToTree converts a Postfix token queue to a parse tree
 func (p *Parser) PostfixToTree(queue *tokenQueue) (*ParseNode, error) {
 	stack := &nodeStack{}
 	currNode := &ParseNode{}
@@ -353,40 +413,58 @@ func (p *Parser) PostfixToTree(queue *tokenQueue) (*ParseNode, error) {
 	for t != nil {
 		t = t.Next
 	}
+	processVariadicArgs := func(parent *ParseNode) (int, error) {
+		if stack.Empty() {
+			return 0, fmt.Errorf("No argCount token found. '%s'", parent.Token.Value)
+		}
+		n := stack.Pop()
+		if n.Token.Type != TokenTypeArgCount {
+			return 0, fmt.Errorf("No argCount token found. '%s'", parent.Token.Value)
+		}
+		argCount, err := strconv.Atoi(n.Token.Value)
+		if err != nil {
+			return 0, err
+		}
+		for i := 0; i < argCount; i++ {
+			if stack.Empty() {
+				return 0, fmt.Errorf("Missing argument found. '%s'", parent.Token.Value)
+			}
+			c := stack.Pop()
+			// Attach the operand to its parent node which represents the function/operator
+			c.Parent = parent
+			// prepend children so they get added in the right order
+			parent.Children = append([]*ParseNode{c}, parent.Children...)
+		}
+		return argCount, nil
+	}
 	for !queue.Empty() {
 		// push the token onto the stack as a tree node
-		currNode = &ParseNode{queue.Dequeue(), nil, make([]*ParseNode, 0)}
+		currToken := queue.Dequeue()
+		currNode = &ParseNode{currToken, nil, make([]*ParseNode, 0)}
 		stack.Push(currNode)
 
 		if _, ok := p.Functions[stack.Peek().Token.Value]; ok {
 			// if the top of the stack is a function
 			node := stack.Pop()
 			f := p.Functions[node.Token.Value]
-			// pop off function parameters
-			idx := 0
-			argCount := f.Params[idx]
-			for i := 0; i < argCount; i++ {
-				if stack.Empty() {
-					// Some functions, e.g. substring, can take a variable number of arguments.
-					foundMatch := false
-					for idx < (len(f.Params) - 1) {
-						idx++
-						argCount = f.Params[idx]
-						if i == argCount {
-							foundMatch = true
-							break
-						}
-					}
-					if !foundMatch {
-						return nil, fmt.Errorf("Insufficient number of operands for function '%s'", node.Token.Value)
-					} else {
+			// Pop off function parameters
+			// The first token is the number of function arguments, which is useful
+			// when parsing variadic functions.
+			// Some functions, e.g. substring, can take a variable number of arguments.
+			if argCount, err := processVariadicArgs(node); err != nil {
+				return nil, err
+			} else {
+				foundMatch := false
+				for _, expectedArgCount := range f.Params {
+					if argCount == expectedArgCount {
+						foundMatch = true
 						break
 					}
 				}
-				// prepend children so they get added in the right order
-				c := stack.Pop()
-				c.Parent = node
-				node.Children = append([]*ParseNode{c}, node.Children...)
+				if !foundMatch {
+					return nil, fmt.Errorf("Invalid number of arguments for function '%s'. Got %d argument",
+						node.Token.Value, argCount)
+				}
 			}
 			stack.Push(node)
 		} else if _, ok := p.Operators[stack.Peek().Token.Value]; ok {
@@ -404,23 +482,14 @@ func (p *Parser) PostfixToTree(queue *tokenQueue) (*ParseNode, error) {
 				node.Children = append([]*ParseNode{c}, node.Children...)
 			}
 			stack.Push(node)
-		} else if stack.Peek().Token.Value == ")" {
-			// This is a multi-value operand, such as the 'in' operator.
-			// In this case, the parenthesis is not used as a precedence delimiter.
-			// Pop the close parenthesis.
-			stack.Pop()
-			var children []*ParseNode
-			for !stack.Empty() && stack.Peek().Token.Value != "(" {
-				// prepend children so they get added in the right order
-				children = append([]*ParseNode{stack.Pop()}, children...)
-			}
-			// Pop the open parenthesis
+		} else if stack.Peek().Token.Type == TokenTypeListExpr {
+			// ListExpr: List of items
 			node := stack.Pop()
-			for _, v := range children {
-				v.Parent = node
+			if _, err := processVariadicArgs(node); err != nil {
+				return nil, err
 			}
-			node.Children = children
 			stack.Push(node)
+
 		}
 	}
 	return currNode, nil
@@ -432,12 +501,13 @@ type tokenStack struct {
 }
 
 type tokenStackNode struct {
-	Token *Token
-	Prev  *tokenStackNode
+	Token      *Token          // The token value.
+	Prev       *tokenStackNode // The previous node in the stack.
+	tokenCount int             // The number of arguments in a listExpr.
 }
 
 func (s *tokenStack) Push(t *Token) {
-	node := tokenStackNode{t, s.Head}
+	node := tokenStackNode{Token: t, Prev: s.Head}
 	//fmt.Println("Pushed:", t.Value, "->", s.String())
 	s.Head = &node
 	s.Size++
@@ -457,6 +527,16 @@ func (s *tokenStack) Peek() *Token {
 
 func (s *tokenStack) Empty() bool {
 	return s.Head == nil
+}
+
+func (s *tokenStack) incrementListArgCount() {
+	if !s.Empty() && s.Head.Token.Value == "(" {
+		s.Head.tokenCount++
+	}
+}
+
+func (s *tokenStack) getArgCount() int {
+	return s.Head.tokenCount
 }
 
 func (s *tokenStack) String() string {
@@ -494,6 +574,7 @@ func (q *tokenQueue) Enqueue(t *Token) {
 	q.Tail = &node
 }
 
+// Dequeue removes the token at the head of the queue and returns the token.
 func (q *tokenQueue) Dequeue() *Token {
 	node := q.Head
 	if node.Next != nil {
@@ -511,13 +592,26 @@ func (q *tokenQueue) Empty() bool {
 }
 
 func (q *tokenQueue) String() string {
-	result := ""
+	var sb strings.Builder
 	node := q.Head
 	for node != nil {
-		result += node.Token.Value
+		sb.WriteString(node.Token.Value)
+		node = node.Next
+		if node != nil {
+			sb.WriteRune(' ')
+		}
+	}
+	return sb.String()
+}
+
+func (q *tokenQueue) GetValue() string {
+	var sb strings.Builder
+	node := q.Head
+	for node != nil {
+		sb.WriteString(node.Token.Value)
 		node = node.Next
 	}
-	return result
+	return sb.String()
 }
 
 type nodeStack struct {
@@ -549,11 +643,12 @@ func (s *nodeStack) Empty() bool {
 }
 
 func (s *nodeStack) String() string {
-	output := ""
+	var sb strings.Builder
 	currNode := s.Head
 	for currNode != nil {
-		output += " " + currNode.ParseNode.Token.Value
+		sb.WriteRune(' ')
+		sb.WriteString(currNode.ParseNode.Token.Value)
 		currNode = currNode.Prev
 	}
-	return output
+	return sb.String()
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -9,11 +9,11 @@ func TestPEMDAS(t *testing.T) {
 	parser := EmptyParser()
 	parser.DefineFunction("sin", []int{1})
 	parser.DefineFunction("max", []int{2})
-	parser.DefineOperator("^", 2, OpAssociationRight, 5, false)
-	parser.DefineOperator("*", 2, OpAssociationLeft, 5, false)
-	parser.DefineOperator("/", 2, OpAssociationLeft, 5, false)
-	parser.DefineOperator("+", 2, OpAssociationLeft, 4, false)
-	parser.DefineOperator("-", 2, OpAssociationLeft, 4, false)
+	parser.DefineOperator("^", 2, OpAssociationRight, 5)
+	parser.DefineOperator("*", 2, OpAssociationLeft, 5)
+	parser.DefineOperator("/", 2, OpAssociationLeft, 5)
+	parser.DefineOperator("+", 2, OpAssociationLeft, 4)
+	parser.DefineOperator("-", 2, OpAssociationLeft, 4)
 
 	// 3 + 4 * 2 / ( 1 - 5 ) ^ 2 ^ 3
 	tokens := []*Token{
@@ -63,11 +63,11 @@ func BenchmarkPEMDAS(b *testing.B) {
 	parser := EmptyParser()
 	parser.DefineFunction("sin", []int{1})
 	parser.DefineFunction("max", []int{2})
-	parser.DefineOperator("^", 2, OpAssociationRight, 5, false)
-	parser.DefineOperator("*", 2, OpAssociationLeft, 5, false)
-	parser.DefineOperator("/", 2, OpAssociationLeft, 5, false)
-	parser.DefineOperator("+", 2, OpAssociationLeft, 4, false)
-	parser.DefineOperator("-", 2, OpAssociationLeft, 4, false)
+	parser.DefineOperator("^", 2, OpAssociationRight, 5)
+	parser.DefineOperator("*", 2, OpAssociationLeft, 5)
+	parser.DefineOperator("/", 2, OpAssociationLeft, 5)
+	parser.DefineOperator("+", 2, OpAssociationLeft, 4)
+	parser.DefineOperator("-", 2, OpAssociationLeft, 4)
 
 	// 3 + 4 * 2 / ( 1 - 5 ) ^ 2 ^ 3
 	tokens := []*Token{
@@ -95,9 +95,9 @@ func BenchmarkPEMDAS(b *testing.B) {
 
 func TestBoolean(t *testing.T) {
 	parser := EmptyParser()
-	parser.DefineOperator("NOT", 1, OpAssociationNone, 3, false)
-	parser.DefineOperator("AND", 2, OpAssociationLeft, 2, false)
-	parser.DefineOperator("OR", 2, OpAssociationLeft, 1, false)
+	parser.DefineOperator("NOT", 1, OpAssociationNone, 3)
+	parser.DefineOperator("AND", 2, OpAssociationLeft, 2)
+	parser.DefineOperator("OR", 2, OpAssociationLeft, 1)
 
 	// (A OR NOT B) AND C OR B
 	tokens := []*Token{
@@ -141,11 +141,11 @@ func TestFunc(t *testing.T) {
 	parser.DefineFunction("sin", []int{1})
 	parser.DefineFunction("max", []int{2})
 	parser.DefineFunction("volume", []int{3})
-	parser.DefineOperator("^", 2, OpAssociationRight, 5, false)
-	parser.DefineOperator("*", 2, OpAssociationLeft, 5, false)
-	parser.DefineOperator("/", 2, OpAssociationLeft, 5, false)
-	parser.DefineOperator("+", 2, OpAssociationLeft, 4, false)
-	parser.DefineOperator("-", 2, OpAssociationLeft, 4, false)
+	parser.DefineOperator("^", 2, OpAssociationRight, 5)
+	parser.DefineOperator("*", 2, OpAssociationLeft, 5)
+	parser.DefineOperator("/", 2, OpAssociationLeft, 5)
+	parser.DefineOperator("+", 2, OpAssociationLeft, 4)
+	parser.DefineOperator("-", 2, OpAssociationLeft, 4)
 
 	// max(sin(5*pi)+3, sin(5)+volume(3,2,4)/[]int{3})
 	tokens := []*Token{
@@ -180,8 +180,10 @@ func TestFunc(t *testing.T) {
 
 	// 5 pi * sin 3 + 5 sin 3 2 4 volume 2 / + max
 	expected := []string{
-		"5", "pi", "*", "sin", "3", "+", "5", "sin", "3", "2", "4", "volume", "2",
-		"/", "+", "max"}
+		"5", "pi", "*", "1" /* arg count */, "sin", "3", "+", "5", "1" /* arg count */, "sin",
+		"3", "2", "4", "3" /* arg count */, "volume", "2",
+		"/", "+",
+		"2" /* arg count */, "max"}
 	result, err := parser.InfixToPostfix(tokens)
 
 	if err != nil {
@@ -207,11 +209,11 @@ func TestTree(t *testing.T) {
 	parser := EmptyParser()
 	parser.DefineFunction("sin", []int{1})
 	parser.DefineFunction("max", []int{2})
-	parser.DefineOperator("^", 2, OpAssociationRight, 5, false)
-	parser.DefineOperator("*", 2, OpAssociationLeft, 5, false)
-	parser.DefineOperator("/", 2, OpAssociationLeft, 5, false)
-	parser.DefineOperator("+", 2, OpAssociationLeft, 4, false)
-	parser.DefineOperator("-", 2, OpAssociationLeft, 4, false)
+	parser.DefineOperator("^", 2, OpAssociationRight, 5)
+	parser.DefineOperator("*", 2, OpAssociationLeft, 5)
+	parser.DefineOperator("/", 2, OpAssociationLeft, 5)
+	parser.DefineOperator("+", 2, OpAssociationLeft, 4)
+	parser.DefineOperator("-", 2, OpAssociationLeft, 4)
 
 	// sin ( max ( 2, 3 ) / 3 * 3.1415 )
 	tokens := []*Token{
@@ -272,11 +274,11 @@ func BenchmarkBuildTree(b *testing.B) {
 	parser := EmptyParser()
 	parser.DefineFunction("sin", []int{1})
 	parser.DefineFunction("max", []int{2})
-	parser.DefineOperator("^", 2, OpAssociationRight, 5, false)
-	parser.DefineOperator("*", 2, OpAssociationLeft, 5, false)
-	parser.DefineOperator("/", 2, OpAssociationLeft, 5, false)
-	parser.DefineOperator("+", 2, OpAssociationLeft, 4, false)
-	parser.DefineOperator("-", 2, OpAssociationLeft, 4, false)
+	parser.DefineOperator("^", 2, OpAssociationRight, 5)
+	parser.DefineOperator("*", 2, OpAssociationLeft, 5)
+	parser.DefineOperator("/", 2, OpAssociationLeft, 5)
+	parser.DefineOperator("+", 2, OpAssociationLeft, 4)
+	parser.DefineOperator("-", 2, OpAssociationLeft, 4)
 
 	// sin ( max ( 2, 3 ) / 3 * 3.1415 )
 	tokens := []*Token{

--- a/request_model.go
+++ b/request_model.go
@@ -15,8 +15,10 @@ const (
 	RequestKindCount
 )
 
+type SemanticType int
+
 const (
-	SemanticTypeUnknown int = iota
+	SemanticTypeUnknown SemanticType = iota
 	SemanticTypeEntity
 	SemanticTypeEntitySet
 	SemanticTypeDerivedEntity
@@ -43,7 +45,7 @@ type GoDataSegment struct {
 	RawValue string
 
 	// The kind of resource being pointed at by this segment
-	SemanticType int
+	SemanticType SemanticType
 
 	// A pointer to the metadata type this object represents, as defined by a
 	// particular service

--- a/search_parser.go
+++ b/search_parser.go
@@ -44,8 +44,8 @@ func SearchTokenizer() *Tokenizer {
 
 func SearchParser() *Parser {
 	parser := EmptyParser()
-	parser.DefineOperator("NOT", 1, OpAssociationNone, 3, false)
-	parser.DefineOperator("AND", 2, OpAssociationLeft, 2, false)
-	parser.DefineOperator("OR", 2, OpAssociationLeft, 1, false)
+	parser.DefineOperator("NOT", 1, OpAssociationNone, 3)
+	parser.DefineOperator("AND", 2, OpAssociationLeft, 2)
+	parser.DefineOperator("OR", 2, OpAssociationLeft, 1)
 	return parser
 }


### PR DESCRIPTION
1. Better support of variadic functions, i.e. functions that have a variable number of arguments
1. Fix handling of **duration** type
1. Improved parsing of `listExpr` vs `parenExpr`
    1. Disambiguate when the list contains zero or one argument.
    1. Support `listExpr` on the left side of `IN` operator.
1. Add unit tests
1. Fix **precedence** value of `in` operator
1. Support case when `any` lambda operator uses top-level property such as `Tags/any(t:t eq 'Site')`. The any operator applies a Boolean expression to each member of a collection and returns true if and only if the expression is true for any member of the collection, otherwise it returns false. This implies that the any operator always returns false for an empty collection.
1. Support case when `any` lambda operator has no parameter such as `Tags/any()`. The any operator can be used without an argument expression. This short form returns false if and only if the collection is empty.
1. Add support for **GUID** token type

```
duration      = [ "duration" ] SQUOTE durationValue SQUOTE
durationValue = [ SIGN ] "P" [ 1*DIGIT "D" ] [ "T" [ 1*DIGIT "H" ] [ 1*DIGIT "M" ] [ 1*DIGIT [ "." 1*DIGIT ] "S" ] ]
```