### PR TITLE
Fixed "result.At undefined" error

### DIFF
--- a/request_model.go
+++ b/request_model.go
@@ -75,6 +75,7 @@ type GoDataQuery struct {
 	InlineCount *GoDataInlineCountQuery
 	Search      *GoDataSearchQuery
 	Format      *GoDataFormatQuery
+	At          *GoDataFilterQuery
 }
 
 // Stores a parsed version of the filter query string. Can be used by


### PR DESCRIPTION
When I try to use the latest version of the package, I get the following error:

    ./url_parser.go:258:9: result.At undefined (type *GoDataQuery has no field or method At)

This PR fixes this issue by defining `At` on `GoDataQuery`
