### PR TITLE
Improve handling of invalid expressions

### DIFF
--- a/expression_parser.go
+++ b/expression_parser.go
@@ -266,7 +266,7 @@ func NewExpressionParser() *ExpressionParser {
 	// City in ('Seattle') needs to be interpreted as a list expression, not a paren expression.
 	parser.DefineOperator("in", 2, OpAssociationLeft, 8).WithListExprPreference(true)
 	parser.DefineOperator("-", 1, OpAssociationNone, 7)
-	parser.DefineOperator("not", 1, OpAssociationLeft, 7)
+	parser.DefineOperator("not", 1, OpAssociationRight, 7)
 	parser.DefineOperator("cast", 2, OpAssociationNone, 7)
 	parser.DefineOperator("mul", 2, OpAssociationNone, 6)
 	parser.DefineOperator("div", 2, OpAssociationNone, 6)   // Division
@@ -282,7 +282,7 @@ func NewExpressionParser() *ExpressionParser {
 	parser.DefineOperator("ne", 2, OpAssociationLeft, 3)
 	parser.DefineOperator("and", 2, OpAssociationLeft, 2)
 	parser.DefineOperator("or", 2, OpAssociationLeft, 1)
-	parser.DefineOperator("=", 2, OpAssociationLeft, 0) // Function argument assignment. E.g. MyFunc(Arg1='abc')
+	parser.DefineOperator("=", 2, OpAssociationRight, 0) // Function argument assignment. E.g. MyFunc(Arg1='abc')
 	parser.DefineFunction("contains", []int{2})
 	parser.DefineFunction("endswith", []int{2})
 	parser.DefineFunction("startswith", []int{2})

--- a/expression_parser_fixture_test.go
+++ b/expression_parser_fixture_test.go
@@ -1180,4 +1180,32 @@ var testCases = []struct {
 			{Value: "'abc123'", Depth: 2, Type: ExpressionTokenString},
 		},
 	},
+	{
+		expression: "not not true",
+		tree: []expectedParseNode{
+			{Value: "not", Depth: 0, Type: ExpressionTokenLogical},
+			{Value: "not", Depth: 1, Type: ExpressionTokenLogical},
+			{Value: "true", Depth: 2, Type: ExpressionTokenBoolean},
+		},
+	},
+	{
+		// duration      = [ "duration" ] SQUOTE durationValue SQUOTE
+		expression: "TaskDuration eq duration'P12DT23H59M59.999999999999S'",
+		tree: []expectedParseNode{
+			{Value: "eq", Depth: 0, Type: ExpressionTokenLogical},
+			{Value: "TaskDuration", Depth: 1, Type: ExpressionTokenLiteral},
+			{Value: "P12DT23H59M59.999999999999S", Depth: 1, Type: ExpressionTokenDuration},
+		},
+	},
+	{
+		expression: "totalseconds(EndTime sub StartTime) lt duration'PT23H59M'",
+		tree: []expectedParseNode{
+			{Value: "lt", Depth: 0, Type: ExpressionTokenLogical},
+			{Value: "totalseconds", Depth: 1, Type: ExpressionTokenFunc},
+			{Value: "sub", Depth: 2, Type: ExpressionTokenOp},
+			{Value: "EndTime", Depth: 3, Type: ExpressionTokenLiteral},
+			{Value: "StartTime", Depth: 3, Type: ExpressionTokenLiteral},
+			{Value: "PT23H59M", Depth: 1, Type: ExpressionTokenDuration},
+		},
+	},
 }

--- a/expression_parser_test.go
+++ b/expression_parser_test.go
@@ -268,6 +268,8 @@ func TestInvalidExpressionSyntax(t *testing.T) {
 		"contains(LastName, 'Smith'",   // Missing closing parenthesis
 		"contains LastName, 'Smith')",  // Missing open parenthesis
 		"City eq 'Dallas' 'Houston'",   // extraneous string value
+		"(numCore neq 12)",
+		"numCore neq 12",
 		//"contains(Name, 'a', 'b', 'c', 'd')", // Too many function arguments
 	}
 	p := NewExpressionParser()

--- a/expression_parser_test.go
+++ b/expression_parser_test.go
@@ -2,6 +2,7 @@ package godata
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -68,7 +69,10 @@ func TestValidBooleanExpressionSyntax(t *testing.T) {
 		"not true",
 		"not false",
 		"not (not true)",
-		//"not not true", // TODO: I think this should work. 'not not true' is true
+		// TODO: this should work because 'not' is inherently right-associative.
+		// I.e. it should be interpreted as not (not true)
+		// If it were left-associative, it would be interpreted as (not not) true, which is invalid.
+		"not not true",
 		// String functions
 		"contains(CompanyName,'freds')",
 		"endswith(CompanyName,'Futterkiste')",
@@ -85,12 +89,12 @@ func TestValidBooleanExpressionSyntax(t *testing.T) {
 		"trim(CompanyName) eq 'Alfreds Futterkiste'",
 		"concat(concat(City,', '), Country) eq 'Berlin, Germany'",
 		// GUID
-		"GuidValue eq 01234567-89ab-cdef-0123-456789abcdef", // TODO According to ODATA ABNF notation, GUID values do not have quotes.
+		"GuidValue eq 01234567-89ab-cdef-0123-456789abcdef", // According to ODATA ABNF notation, GUID values do not have quotes.
 		// Date and Time functions
 		"StartDate eq 2012-12-03",
 		"DateTimeOffsetValue eq 2012-12-03T07:16:23Z",
 		// duration      = [ "duration" ] SQUOTE durationValue SQUOTE
-		// "DurationValue eq duration'P12DT23H59M59.999999999999S'", // TODO See ODATA ABNF notation
+		"DurationValue eq duration'P12DT23H59M59.999999999999S'", // See ODATA ABNF notation
 		"TimeOfDayValue eq 07:59:59.999",
 		"year(BirthDate) eq 0",
 		"month(BirthDate) eq 12",
@@ -106,7 +110,7 @@ func TestValidBooleanExpressionSyntax(t *testing.T) {
 		"date(StartTime) ne date(EndTime)",
 		"totaloffsetminutes(StartTime) eq 60",
 		"StartTime eq mindatetime()",
-		// "totalseconds(EndTime sub StartTime) lt duration'PT23H59'", // TODO The totalseconds function returns the duration of the value in total seconds, including fractional seconds.
+		"totalseconds(EndTime sub StartTime) lt duration'PT23H59M'", // The totalseconds function returns the duration of the value in total seconds, including fractional seconds.
 		"EndTime eq maxdatetime()",
 		"time(StartTime) le StartOfDay",
 		"time('2015-10-14T23:30:00.104+02:00') lt now()",
@@ -199,17 +203,16 @@ func TestValidBooleanExpressionSyntax(t *testing.T) {
 	p := NewExpressionParser()
 	p.ExpectBoolExpr = true
 	for _, input := range queries {
+		t.Logf("Testing expression %s", input)
 		q, err := p.ParseExpressionString(input)
 		if err != nil {
 			t.Errorf("Error parsing query '%s'. Error: %v", input, err)
 		} else {
 			if q.Tree == nil {
 				t.Errorf("Error parsing query '%s'. Tree is nil", input)
-			}
-			if q.Tree.Token == nil {
+			} else if q.Tree.Token == nil {
 				t.Errorf("Error parsing query '%s'. Root token is nil", input)
-			}
-			if q.Tree.Token.Type == ExpressionTokenLiteral {
+			} else if q.Tree.Token.Type == ExpressionTokenLiteral {
 				t.Errorf("Error parsing query '%s'. Unexpected root token type: %+v", input, q.Tree.Token)
 			}
 		}
@@ -220,8 +223,8 @@ func TestValidBooleanExpressionSyntax(t *testing.T) {
 // The URLs below are not valid ODATA syntax, the parser should return an error.
 func TestInvalidBooleanExpressionSyntax(t *testing.T) {
 	queries := []string{
-		"(TRUE)",
-		"(City)",
+		"(TRUE)",  // Should be true lowercase
+		"(City)",  // The literal City is not boolean
 		"12345",   // Number 12345 is not a boolean expression
 		"0",       // Number 0 is not a boolean expression
 		"'123'",   // String '123' is not a boolean expression
@@ -231,9 +234,8 @@ func TestInvalidBooleanExpressionSyntax(t *testing.T) {
 		"no",      // yes is not a boolean expression, though it's a literal value
 		"add 2 3", // Missing operands
 		"City",    // Just a single literal
-		// TODO: the query below should fail.
-		//"Tags/any(var:var/Key eq 'Site') orTags/any(var:var/Key eq 'Site')",
-		//"contains(Name, 'a', 'b', 'c', 'd')", // Too many function arguments
+		"Tags/any(var:var/Key eq 'Site') orTags/any(var:var/Key eq 'Site')",
+		"contains(Name, 'a', 'b', 'c', 'd')", // Too many function arguments
 	}
 	p := NewExpressionParser()
 	p.ExpectBoolExpr = true
@@ -468,4 +470,55 @@ func TestExpressions(t *testing.T) {
 		}
 	}
 
+}
+func TestDuration(t *testing.T) {
+	testCases := []struct {
+		value string
+		valid bool
+	}{
+		{value: "duration'P12DT23H59M59.999999999999S'", valid: true},
+		// three years, six months, four days, twelve hours, thirty minutes, and five seconds
+		{value: "duration'P3Y6M4DT12H30M5S'", valid: true},
+		// Date and time elements including their designator may be omitted if their value is zero,
+		// and lower-order elements may also be omitted for reduced precision.
+		{value: "duration'P23DT23H'", valid: true},
+		{value: "duration'P4Y'", valid: true},
+		// However, at least one element must be present,
+		// thus "P" is not a valid representation for a duration of 0 seconds.
+		{value: "duration'P'", valid: false},
+		// "PT0S" or "P0D", however, are both valid and represent the same duration.
+		{value: "duration'PT0S'", valid: true},
+		{value: "duration'P0D'", valid: true},
+		// To resolve ambiguity, "P1M" is a one-month duration and "PT1M" is a one-minute duration
+		{value: "duration'P1M'", valid: true},
+		{value: "duration'PT1M'", valid: true},
+		// The standard does not prohibit date and time values in a duration representation
+		// from exceeding their "carry over points" except as noted below.
+		// Thus, "PT36H" could be used as well as "P1DT12H" for representing the same duration.
+		{value: "duration'PT36H'", valid: true},
+		{value: "duration'P1DT12H'", valid: true},
+		{value: "duration'PT23H59M'", valid: true},
+		{value: "duration'PT23H59'", valid: false}, // missing units
+
+		{value: "duration'H0D'", valid: false},
+		{value: "foo", valid: false},
+
+		// TODO: the duration values below should be valid
+		// The smallest value used may also have a decimal fraction,[35] as in "P0.5Y" to indicate half a year.
+		{value: "duration'P0.5Y'", valid: false}, // half a year
+		{value: "duration'P0.5M'", valid: false}, // half a month
+		// This decimal fraction may be specified with either a comma or a full stop, as in "P0,5Y" or "P0.5Y".
+		{value: "duration'P0,5Y'", valid: false},
+	}
+	re, err := regexp.Compile(tokenDurationRe)
+	if err != nil {
+		t.Fatalf("Invalid regex: %v", err)
+	}
+	for _, testCase := range testCases {
+		m := re.MatchString(testCase.value)
+		if m != testCase.valid {
+			t.Errorf("Value: %s. Expected regex match: %v, got %v",
+				testCase.value, testCase.valid, m)
+		}
+	}
 }

--- a/expression_parser_test.go
+++ b/expression_parser_test.go
@@ -296,6 +296,13 @@ func TestInvalidExpressionSyntax(t *testing.T) {
 		"contains(LastName, 'Smith'),", // Extra comma after the function call
 		"contains(LastName, 'Smith',)", // Extra comma after the last argument
 		"contains(,LastName, 'Smith')", // Extra comma before the first argument
+		"eq eq eq",                     // Invalid sequence of operators
+		"not not",                      // Invalid sequence of operators
+		"true true",                    // Invalid sequence of booleans
+		"1 2 3",                        // Invalid sequence of numbers
+		"1.4 2.34 3.1415",              // Invalid sequence of numbers
+		"a b c",                        // Invalid sequence of literals.
+		"'a' 'b' 'c'",                  // Invalid sequence of strings.
 	}
 	p := NewExpressionParser()
 	p.ExpectBoolExpr = false

--- a/expression_parser_test.go
+++ b/expression_parser_test.go
@@ -289,6 +289,13 @@ func TestInvalidExpressionSyntax(t *testing.T) {
 		"(a, b, )",                     // This is not a list.
 		"(a, , b)",                     // This is not a list.
 		"(, a, b)",                     // This is not a list.
+		"(a, not b c)",                 // Missing comma between (not b) and (c)
+		",",                            // A comma by itself is not an expression
+		",,,",                          // A comma by itself is not an expression
+		"(,)",                          // A comma by itself is not an expression
+		"contains(LastName, 'Smith'),", // Extra comma after the function call
+		"contains(LastName, 'Smith',)", // Extra comma after the last argument
+		"contains(,LastName, 'Smith')", // Extra comma before the first argument
 	}
 	p := NewExpressionParser()
 	p.ExpectBoolExpr = false
@@ -339,7 +346,10 @@ func CompareTokens(expected, actual []*Token) (bool, error) {
 	return true, nil
 }
 
-func CompareQueue(expect []*Token, b *tokenQueue) (bool, error) {
+func CompareQueue(expect []*Token, b *tokenQueue) error {
+	if b == nil {
+		return fmt.Errorf("Got nil token queue")
+	}
 	bl := func() int {
 		if b.Empty() {
 			return 0
@@ -351,22 +361,22 @@ func CompareQueue(expect []*Token, b *tokenQueue) (bool, error) {
 		return l
 	}()
 	if len(expect) != bl {
-		return false, fmt.Errorf("Postfix queue unexpected length. Got len=%d, expected %d. queue=%v",
+		return fmt.Errorf("Postfix queue unexpected length. Got len=%d, expected %d. queue=%v",
 			bl, len(expect), b)
 	}
 	node := b.Head
 	for i := range expect {
 		if expect[i].Type != node.Token.Type {
-			return false, fmt.Errorf("Postfix token types at index %d. Got: %v, expected: %v. Expected value: %v",
+			return fmt.Errorf("Postfix token types at index %d. Got: %v, expected: %v. Expected value: %v",
 				i, node.Token.Type, expect[i].Type, expect[i].Value)
 		}
 		if expect[i].Value != node.Token.Value {
-			return false, fmt.Errorf("Postfix token values at index %d. Got: %v, expected: %v",
+			return fmt.Errorf("Postfix token values at index %d. Got: %v, expected: %v",
 				i, node.Token.Value, expect[i].Value)
 		}
 		node = node.Next
 	}
-	return true, nil
+	return nil
 }
 
 func printTokens(tokens []*Token) {
@@ -384,7 +394,11 @@ func CompareTree(node *ParseNode, expect []expectedParseNode, pos *int, level in
 		return fmt.Errorf("Unexpected token at pos %d. Got %s, expected no value",
 			*pos, node.Token.Value)
 	}
-	if node.Token.Value != expect[*pos].Value {
+	if node == nil {
+		return fmt.Errorf("Node should not be nil")
+	}
+	if node.Token.Value !=
+		expect[*pos].Value {
 		return fmt.Errorf("Unexpected token at pos %d. Got %s -> %d, expected: %s -> %d",
 			*pos, node.Token.Value, level, expect[*pos].Value, expect[*pos].Depth)
 	}
@@ -430,7 +444,7 @@ func TestExpressions(t *testing.T) {
 			continue
 		}
 		if testCase.postfixTokens != nil {
-			if result, err := CompareQueue(testCase.postfixTokens, output); !result {
+			if err := CompareQueue(testCase.postfixTokens, output); err != nil {
 				t.Errorf("Unexpected postfix tokens: %v", err)
 				continue
 			}

--- a/expression_parser_test.go
+++ b/expression_parser_test.go
@@ -286,6 +286,9 @@ func TestInvalidExpressionSyntax(t *testing.T) {
 		"(numCore neq 12)",             // Invalid operator. It should be 'ne'
 		"numCore neq 12",               // Invalid operator. It should be 'ne'
 		"(a b c d e)",                  // This is not a list.
+		"(a, b, )",                     // This is not a list.
+		"(a, , b)",                     // This is not a list.
+		"(, a, b)",                     // This is not a list.
 	}
 	p := NewExpressionParser()
 	p.ExpectBoolExpr = false

--- a/expression_parser_test.go
+++ b/expression_parser_test.go
@@ -218,29 +218,46 @@ func TestValidBooleanExpressionSyntax(t *testing.T) {
 }
 
 // The URLs below are not valid ODATA syntax, the parser should return an error.
+func TestInvalidBooleanExpressionSyntax(t *testing.T) {
+	queries := []string{
+		"(TRUE)",
+		"(City)",
+		"12345",   // Number 12345 is not a boolean expression
+		"0",       // Number 0 is not a boolean expression
+		"'123'",   // String '123' is not a boolean expression
+		"TRUE",    // Should be 'true' lowercase
+		"FALSE",   // Should be 'false' lowercase
+		"yes",     // yes is not a boolean expression, though it's a literal value
+		"no",      // yes is not a boolean expression, though it's a literal value
+		"add 2 3", // Missing operands
+		"City",    // Just a single literal
+		// TODO: the query below should fail.
+		//"Tags/any(var:var/Key eq 'Site') orTags/any(var:var/Key eq 'Site')",
+		//"contains(Name, 'a', 'b', 'c', 'd')", // Too many function arguments
+	}
+	p := NewExpressionParser()
+	p.ExpectBoolExpr = true
+	for _, input := range queries {
+		q, err := p.ParseExpressionString(input)
+		if err == nil {
+			// The parser has incorrectly determined the syntax is valid.
+			t.Errorf("The expression '%s' is not valid ODATA syntax. The ODATA parser should return an error. Tree:\n%v", input, q.Tree)
+		}
+	}
+}
+
 func TestInvalidExpressionSyntax(t *testing.T) {
 	queries := []string{
 		"()", // It's not a boolean expression
-		"(TRUE)",
-		"(City)",
 		"(",
 		"((((",
 		")",
-		"12345",                                // Number 12345 is not a boolean expression
-		"0",                                    // Number 0 is not a boolean expression
-		"'123'",                                // String '123' is not a boolean expression
-		"TRUE",                                 // Should be 'true' lowercase
-		"FALSE",                                // Should be 'false' lowercase
-		"yes",                                  // yes is not a boolean expression
-		"no",                                   // yes is not a boolean expression
 		"",                                     // Empty string.
 		"eq",                                   // Just a single logical operator
 		"and",                                  // Just a single logical operator
 		"add",                                  // Just a single arithmetic operator
 		"add ",                                 // Just a single arithmetic operator
 		"add 2",                                // Missing operands
-		"add 2 3",                              // Missing operands
-		"City",                                 // Just a single literal
 		"City City City City",                  // Sequence of literals
 		"City eq",                              // Missing operand
 		"City eq (",                            // Wrong operand
@@ -255,8 +272,6 @@ func TestInvalidExpressionSyntax(t *testing.T) {
 		"not (City eq 'Dallas'))",              // Extraneous closing parenthesis
 		"not City eq 'Dallas')",                // Missing open parenthesis
 		"City eq 'Dallas' orCity eq 'Houston'", // missing space between or and City
-		// TODO: the query below should fail.
-		//"Tags/any(var:var/Key eq 'Site') orTags/any(var:var/Key eq 'Site')",
 		"not (City eq 'Dallas') and Name eq 'Houston')",
 		"Tags/all()",                   // The all operator cannot be used without an argument expression.
 		"LastName contains 'Smith'",    // Previously the godata library was not returning an error.
@@ -270,11 +285,12 @@ func TestInvalidExpressionSyntax(t *testing.T) {
 		"City eq 'Dallas' 'Houston'",   // extraneous string value
 		"(numCore neq 12)",             // Invalid operator. It should be 'ne'
 		"numCore neq 12",               // Invalid operator. It should be 'ne'
-		//"contains(Name, 'a', 'b', 'c', 'd')", // Too many function arguments
+		"(a b c d e)",                  // This is not a list.
 	}
 	p := NewExpressionParser()
-	p.ExpectBoolExpr = true
+	p.ExpectBoolExpr = false
 	for _, input := range queries {
+		t.Logf("testing: %s", input)
 		q, err := p.ParseExpressionString(input)
 		if err == nil {
 			// The parser has incorrectly determined the syntax is valid.

--- a/expression_parser_test.go
+++ b/expression_parser_test.go
@@ -268,8 +268,8 @@ func TestInvalidExpressionSyntax(t *testing.T) {
 		"contains(LastName, 'Smith'",   // Missing closing parenthesis
 		"contains LastName, 'Smith')",  // Missing open parenthesis
 		"City eq 'Dallas' 'Houston'",   // extraneous string value
-		"(numCore neq 12)",
-		"numCore neq 12",
+		"(numCore neq 12)",             // Invalid operator. It should be 'ne'
+		"numCore neq 12",               // Invalid operator. It should be 'ne'
 		//"contains(Name, 'a', 'b', 'c', 'd')", // Too many function arguments
 	}
 	p := NewExpressionParser()

--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -1308,6 +1308,8 @@ func TestInvalidFilterSyntax(t *testing.T) {
 		"contains(LastName, 'Smith'",   // Missing closing parenthesis
 		"contains LastName, 'Smith')",  // Missing open parenthesis
 		"City eq 'Dallas' 'Houston'",   // extraneous string value
+		"(numCore neq 12)",
+		"numCore neq 12",
 		//"contains(Name, 'a', 'b', 'c', 'd')", // Too many function arguments
 	}
 	for _, input := range queries {

--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -1309,6 +1309,7 @@ func TestInvalidFilterSyntax(t *testing.T) {
 		"contains LastName, 'Smith')",  // Missing open parenthesis
 		"City eq 'Dallas' 'Houston'",   // extraneous string value
 		"(numCore neq 12)",             // Invalid operator. It should be 'ne'
+		"(a b c d)",                    // Invalid list
 		"numCore neq 12",               // Invalid operator. It should be 'ne'
 		//"contains(Name, 'a', 'b', 'c', 'd')", // Too many function arguments
 	}
@@ -1317,7 +1318,6 @@ func TestInvalidFilterSyntax(t *testing.T) {
 		if err == nil {
 			// The parser has incorrectly determined the syntax is valid.
 			t.Errorf("The query '$filter=%s' is not valid ODATA syntax. The ODATA parser should return an error. Tree:\n%v", input, q.Tree)
-			return
 		}
 	}
 }

--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -1142,7 +1142,7 @@ func TestValidFilterSyntax(t *testing.T) {
 		"date(StartTime) ne date(EndTime)",
 		"totaloffsetminutes(StartTime) eq 60",
 		"StartTime eq mindatetime()",
-		// "totalseconds(EndTime sub StartTime) lt duration'PT23H59'", // TODO The totalseconds function returns the duration of the value in total seconds, including fractional seconds.
+		"totalseconds(EndTime sub StartTime) lt duration'PT23H59M'", // TODO The totalseconds function returns the duration of the value in total seconds, including fractional seconds.
 		"EndTime eq maxdatetime()",
 		"time(StartTime) le StartOfDay",
 		"time('2015-10-14T23:30:00.104+02:00') lt now()",

--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -1308,8 +1308,8 @@ func TestInvalidFilterSyntax(t *testing.T) {
 		"contains(LastName, 'Smith'",   // Missing closing parenthesis
 		"contains LastName, 'Smith')",  // Missing open parenthesis
 		"City eq 'Dallas' 'Houston'",   // extraneous string value
-		"(numCore neq 12)",
-		"numCore neq 12",
+		"(numCore neq 12)",             // Invalid operator. It should be 'ne'
+		"numCore neq 12",               // Invalid operator. It should be 'ne'
 		//"contains(Name, 'a', 'b', 'c', 'd')", // Too many function arguments
 	}
 	for _, input := range queries {

--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -1,7 +1,6 @@
 package godata
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 )
@@ -550,8 +549,7 @@ func TestFilterInOperator(t *testing.T) {
 		{Value: TokenListExpr, Type: TokenTypeListExpr},
 		{Value: "in", Type: ExpressionTokenLogical},
 	}
-	result, err = CompareQueue(expect, postfix)
-	if !result {
+	if err := CompareQueue(expect, postfix); err != nil {
 		t.Error(err)
 	}
 
@@ -607,8 +605,7 @@ func TestFilterInOperatorSingleValue(t *testing.T) {
 		{Value: TokenListExpr, Type: TokenTypeListExpr},
 		{Value: "in", Type: ExpressionTokenLogical},
 	}
-	result, err = CompareQueue(expect, postfix)
-	if !result {
+	if err := CompareQueue(expect, postfix); err != nil {
 		t.Error(err)
 	}
 
@@ -643,16 +640,16 @@ func TestFilterInOperatorEmptyList(t *testing.T) {
 	}
 	tokens, err := tokenizer.Tokenize(input)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	result, err := CompareTokens(expect, tokens)
 	if !result {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	var postfix *tokenQueue
 	postfix, err = GlobalFilterParser.InfixToPostfix(tokens)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	expect = []*Token{
 		{Value: "City", Type: ExpressionTokenLiteral},
@@ -660,14 +657,13 @@ func TestFilterInOperatorEmptyList(t *testing.T) {
 		{Value: TokenListExpr, Type: TokenTypeListExpr},
 		{Value: "in", Type: ExpressionTokenLogical},
 	}
-	result, err = CompareQueue(expect, postfix)
-	if !result {
-		t.Error(err)
+	if err := CompareQueue(expect, postfix); err != nil {
+		t.Fatal(err)
 	}
 
 	tree, err := GlobalFilterParser.PostfixToTree(postfix)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	var treeExpect []expectedParseNode = []expectedParseNode{
@@ -722,16 +718,16 @@ func TestFilterInOperatorBothSides(t *testing.T) {
 	}
 	tokens, err := tokenizer.Tokenize(input)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	result, err := CompareTokens(expect, tokens)
 	if !result {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	var postfix *tokenQueue
 	postfix, err = GlobalFilterParser.InfixToPostfix(tokens)
 	if err != nil {
-		t.Error(err)
+		t.Fatalf("failed to convert from infix to postfix: %v", err)
 	}
 	expect = []*Token{
 		{Value: "1", Type: ExpressionTokenInteger},
@@ -740,34 +736,32 @@ func TestFilterInOperatorBothSides(t *testing.T) {
 		{Value: TokenListExpr, Type: TokenTypeListExpr},
 
 		{Value: "'ab'", Type: ExpressionTokenString},
-		{Value: "'cd'", Type: ExpressionTokenString},
+		{Value: "'cd'", Type: ExpressionTokenString}, // idx 5
 		{Value: "2", Type: TokenTypeArgCount},
 		{Value: TokenListExpr, Type: TokenTypeListExpr},
 
 		{Value: "1", Type: ExpressionTokenInteger},
 		{Value: "2", Type: ExpressionTokenInteger},
-		{Value: "2", Type: TokenTypeArgCount},
+		{Value: "2", Type: TokenTypeArgCount}, // idx 10
 		{Value: TokenListExpr, Type: TokenTypeListExpr},
 
 		{Value: "'abc'", Type: ExpressionTokenString},
 		{Value: "'def'", Type: ExpressionTokenString},
 		{Value: "2", Type: TokenTypeArgCount},
-		{Value: TokenListExpr, Type: TokenTypeListExpr},
+		{Value: TokenListExpr, Type: TokenTypeListExpr}, // idx 15
 
 		{Value: "3", Type: TokenTypeArgCount},
 		{Value: TokenListExpr, Type: TokenTypeListExpr},
 
 		{Value: "in", Type: ExpressionTokenLogical},
 	}
-	result, err = CompareQueue(expect, postfix)
-	if !result {
-		fmt.Printf("postfix notation: %s\n", postfix.String())
-		t.Error(err)
+	if err := CompareQueue(expect, postfix); err != nil {
+		t.Fatalf("Unexpected postfix notation: %v. Error: %v", postfix, err)
 	}
 
 	tree, err := GlobalFilterParser.PostfixToTree(postfix)
 	if err != nil {
-		t.Error(err)
+		t.Fatalf("Failed to convert postfix to tree: %v", err)
 	}
 
 	var treeExpect []expectedParseNode = []expectedParseNode{
@@ -1675,8 +1669,7 @@ func TestFilterSubstringofFunction(t *testing.T) {
 			{Value: "true", Type: ExpressionTokenBoolean},
 			{Value: "eq", Type: ExpressionTokenLogical},
 		}
-		result, err := CompareQueue(expect, output)
-		if !result {
+		if err := CompareQueue(expect, output); err != nil {
 			t.Error(err)
 		}
 	}
@@ -1752,8 +1745,7 @@ func TestFilterSubstringNestedFunction(t *testing.T) {
 			{Value: "'ci'", Type: ExpressionTokenString},
 			{Value: "eq", Type: ExpressionTokenLogical},
 		}
-		result, err := CompareQueue(expect, output)
-		if !result {
+		if err := CompareQueue(expect, output); err != nil {
 			t.Error(err)
 		}
 	}
@@ -1870,9 +1862,7 @@ func TestFilterLambdaAnyNot(t *testing.T) {
 			{Value: "any", Type: ExpressionTokenLambda},
 			{Value: "/", Type: ExpressionTokenLambdaNav},
 		}
-		var result bool
-		result, err = CompareQueue(expect, output)
-		if !result {
+		if err = CompareQueue(expect, output); err != nil {
 			t.Error(err)
 		}
 	}

--- a/parser.go
+++ b/parser.go
@@ -317,19 +317,33 @@ func (p *Parser) InfixToPostfix(tokens []*Token) (*tokenQueue, error) {
 	queue := tokenQueue{} // output queue in postfix
 	stack := tokenStack{} // Operator stack
 
+	previousTokenIsLiteral := false
+	var previousToken *Token = nil
+
+	incrementListArgCount := func(token *Token) {
+		if !stack.Empty() {
+			if previousToken != nil && previousToken.Value == TokenOpenParen {
+				stack.Head.listArgCount++
+			} else if stack.Head.Token.Value == TokenOpenParen {
+				stack.Head.listArgCount++
+			}
+		}
+	}
 	for len(tokens) > 0 {
 		token := tokens[0]
 		tokens = tokens[1:]
 		switch {
 		case p.isFunction(token):
+			previousTokenIsLiteral = false
 			if len(tokens) == 0 || tokens[0].Value != TokenOpenParen {
 				// A function token must be followed by open parenthesis token.
 				return nil, BadRequestError(fmt.Sprintf("Function '%s' must be followed by '('", token.Value))
 			}
-			stack.incrementListArgCount()
+			incrementListArgCount(token)
 			// push functions onto the stack
 			stack.Push(token)
 		case p.isOperator(token):
+			previousTokenIsLiteral = false
 			// push operators onto stack according to precedence
 			o1 := p.Operators[token.Value]
 			if !stack.Empty() {
@@ -345,10 +359,11 @@ func (p *Parser) InfixToPostfix(tokens []*Token) (*tokenQueue, error) {
 				}
 			}
 			if o1.Operands == 1 { // not, -
-				stack.incrementListArgCount()
+				incrementListArgCount(token)
 			}
 			stack.Push(token)
 		case token.Value == TokenOpenParen:
+			previousTokenIsLiteral = false
 			// In OData, the parenthesis tokens can be used:
 			// - As a parenExpr to set explicit precedence order, such as "(a + 2) x b"
 			//   These precedence tokens are removed while parsing the OData query.
@@ -356,10 +371,14 @@ func (p *Parser) InfixToPostfix(tokens []*Token) (*tokenQueue, error) {
 			//   The list tokens are retained while parsing the OData query.
 			//   ABNF grammar:
 			//   listExpr  = OPEN BWS commonExpr BWS *( COMMA BWS commonExpr BWS ) CLOSE
-			stack.incrementListArgCount()
+			incrementListArgCount(token)
 			// Push open parens onto the stack
 			stack.Push(token)
 		case token.Value == TokenCloseParen:
+			previousTokenIsLiteral = false
+			if previousToken != nil && previousToken.Value == TokenComma {
+				return nil, fmt.Errorf("invalid token sequence: %s %s", previousToken.Value, token.Value)
+			}
 			// if we find a close paren, pop things off the stack
 			for !stack.Empty() {
 				if stack.Peek().Value == TokenOpenParen {
@@ -437,18 +456,6 @@ func (p *Parser) InfixToPostfix(tokens []*Token) (*tokenQueue, error) {
 			//           or should (1) be simplified to the integer 1, which is contained in the RHS?
 			//   1 in ( ('a', 'b', 'c'), (2), 1 )
 			//       ==> true. The number 1 is contained in the RHS list.
-			/*
-				switch {
-				case argCount <= 1:
-					if !isListExpr && len(tokens) > 0 {
-						if o1, ok := p.Operators[tokens[0].Value]; ok {
-							// The expression is the left operand of an operator that has a preference for listExpr vs parenExpr.
-							if o1.PreferListExpr {
-								isListExpr = true
-							}
-						}
-					}
-			*/
 			if isListExpr {
 				// The open parenthesis was a delimiter for a listExpr.
 				// Add a token indicating the number of arguments in the list.
@@ -467,6 +474,13 @@ func (p *Parser) InfixToPostfix(tokens []*Token) (*tokenQueue, error) {
 				queue.Enqueue(stack.Pop())
 			}
 		case token.Value == TokenComma:
+			previousTokenIsLiteral = false
+			if previousToken != nil {
+				switch previousToken.Value {
+				case TokenComma, TokenOpenParen:
+					return nil, fmt.Errorf("invalid token sequence: %s %s", previousToken.Value, token.Value)
+				}
+			}
 			// Function argument separator (",")
 			// Comma may be used as:
 			// 1. Separator of function parameters,
@@ -486,17 +500,23 @@ func (p *Parser) InfixToPostfix(tokens []*Token) (*tokenQueue, error) {
 			if stack.Peek().Value != TokenOpenParen {
 				panic("unexpected token")
 			}
+
 		default:
+			if previousTokenIsLiteral {
+				return nil, fmt.Errorf("invalid token sequence: %s %s", previousToken.Value, token.Value)
+			}
 			if token.Type == p.LiteralToken && len(tokens) > 0 && tokens[0].Value == TokenOpenParen {
 				// Literal followed by parenthesis ==> property collection navigation
 				// push property segment onto the stack
 				stack.Push(token)
 			} else {
 				// Token is a literal, number, string... -- put it in the queue
-				stack.incrementListArgCount()
 				queue.Enqueue(token)
 			}
+			incrementListArgCount(token)
+			previousTokenIsLiteral = true
 		}
+		previousToken = token
 	}
 
 	// pop off the remaining operators onto the queue
@@ -514,6 +534,9 @@ func (p *Parser) PostfixToTree(queue *tokenQueue) (*ParseNode, error) {
 	stack := &nodeStack{}
 	currNode := &ParseNode{}
 
+	if queue == nil {
+		return nil, errors.New("input queue is nil")
+	}
 	t := queue.Head
 	for t != nil {
 		t = t.Next
@@ -665,12 +688,6 @@ func (s *tokenStack) Empty() bool {
 	return s.Head == nil
 }
 
-func (s *tokenStack) incrementListArgCount() {
-	if !s.Empty() && s.Head.Token.Value == TokenOpenParen {
-		s.Head.listArgCount++
-	}
-}
-
 func (s *tokenStack) getArgCount() int {
 	return s.Head.listArgCount
 }
@@ -679,7 +696,7 @@ func (s *tokenStack) String() string {
 	output := ""
 	currNode := s.Head
 	for currNode != nil {
-		output += " " + currNode.Token.Value
+		output = currNode.Token.Value + " " + output
 		currNode = currNode.Prev
 	}
 	return output
@@ -731,7 +748,7 @@ func (q *tokenQueue) String() string {
 	var sb strings.Builder
 	node := q.Head
 	for node != nil {
-		sb.WriteString(fmt.Sprintf("%s[%d]", node.Token.Value, node.Token.Type))
+		sb.WriteString(fmt.Sprintf("%s[%v]", node.Token.Value, node.Token.Type))
 		node = node.Next
 		if node != nil {
 			sb.WriteRune(' ')

--- a/parser.go
+++ b/parser.go
@@ -272,7 +272,8 @@ func (p *Parser) WithLiteralToken(token TokenType) *Parser {
 	return p
 }
 
-// DefineOperator adds an operator to the language. Provide the token, the expected number of arguments,
+// DefineOperator adds an operator to the language.
+// Provide the token, the expected number of arguments,
 // whether the operator is left, right, or not associative, and a precedence.
 func (p *Parser) DefineOperator(token string, operands, assoc, precedence int) *Operator {
 	op := &Operator{
@@ -348,8 +349,8 @@ func (p *Parser) InfixToPostfix(tokens []*Token) (*tokenQueue, error) {
 			o1 := p.Operators[token.Value]
 			if !stack.Empty() {
 				for o2, ok := p.Operators[stack.Peek().Value]; ok &&
-					(o1.Association == OpAssociationLeft && o1.Precedence <= o2.Precedence) ||
-					(o1.Association == OpAssociationRight && o1.Precedence < o2.Precedence); {
+					((o1.Association == OpAssociationLeft && o1.Precedence <= o2.Precedence) ||
+						(o1.Association == OpAssociationRight && o1.Precedence < o2.Precedence)); {
 					queue.Enqueue(stack.Pop())
 
 					if stack.Empty() {

--- a/parser.go
+++ b/parser.go
@@ -492,7 +492,7 @@ func (p *Parser) InfixToPostfix(tokens []*Token) (*tokenQueue, error) {
 				// push property segment onto the stack
 				stack.Push(token)
 			} else {
-				// Token is a literal -- put it in the queue
+				// Token is a literal, number, string... -- put it in the queue
 				stack.incrementListArgCount()
 				queue.Enqueue(token)
 			}

--- a/parser_test.go
+++ b/parser_test.go
@@ -237,9 +237,9 @@ func TestTree(t *testing.T) {
 
 	// 2 3 max 3 / 3.1415 * sin
 	result, err := parser.InfixToPostfix(tokens)
-
 	if err != nil {
 		t.Error(err)
+		return
 	}
 
 	root, err := parser.PostfixToTree(result)

--- a/parser_test.go
+++ b/parser_test.go
@@ -238,14 +238,12 @@ func TestTree(t *testing.T) {
 	// 2 3 max 3 / 3.1415 * sin
 	result, err := parser.InfixToPostfix(tokens)
 	if err != nil {
-		t.Error(err)
-		return
+		t.Fatal(err)
 	}
 
 	root, err := parser.PostfixToTree(result)
 	if err != nil {
-		t.Errorf("Error parsing query: %v", err)
-		return
+		t.Fatalf("Error parsing query: %v", err)
 	}
 	if root.Token.Value != "sin" {
 		t.Error("Root node is not sin")


### PR DESCRIPTION
1. Add unit tests for invalid expressions.
2. Return parse error for invalid sequence of tokens:
   1. `f(a, b,)`
   2. `f(a, , b)`
   3. `f(, a, b)`
   4. `(a b c)`
3. Code simplification.
4. Fix panic when operator is configured with right associativity.
5. Set `not` operator to be right associative, i.e. `not not true` should be interpreted as `not ( not true )`
6. Add unit tests for durations.
7. Handle scenario when expression uses invalid operator, such as `numCore neq 12`. It should be `numCore ne 12`