### PR TITLE
add context argument

### DIFF
--- a/apply_parser.go
+++ b/apply_parser.go
@@ -1,6 +1,8 @@
 package godata
 
-func ParseApplyString(apply string) (*GoDataApplyQuery, error) {
+import "context"
+
+func ParseApplyString(ctx context.Context, apply string) (*GoDataApplyQuery, error) {
 	result := GoDataApplyQuery(apply)
 	return &result, nil
 }

--- a/count_parser.go
+++ b/count_parser.go
@@ -1,10 +1,11 @@
 package godata
 
 import (
+	"context"
 	"strconv"
 )
 
-func ParseCountString(count string) (*GoDataCountQuery, error) {
+func ParseCountString(ctx context.Context, count string) (*GoDataCountQuery, error) {
 	i, err := strconv.ParseBool(count)
 	if err != nil {
 		return nil, err

--- a/expand_parser.go
+++ b/expand_parser.go
@@ -52,7 +52,7 @@ func ExpandTokenizer() *Tokenizer {
 }
 
 func ParseExpandString(ctx context.Context, expand string) (*GoDataExpandQuery, error) {
-	tokens, err := GlobalExpandTokenizer.Tokenize(expand)
+	tokens, err := GlobalExpandTokenizer.Tokenize(ctx, expand)
 
 	if err != nil {
 		return nil, err

--- a/expand_parser.go
+++ b/expand_parser.go
@@ -1,6 +1,7 @@
 package godata
 
 import (
+	"context"
 	"strconv"
 )
 
@@ -50,7 +51,7 @@ func ExpandTokenizer() *Tokenizer {
 	return &t
 }
 
-func ParseExpandString(expand string) (*GoDataExpandQuery, error) {
+func ParseExpandString(ctx context.Context, expand string) (*GoDataExpandQuery, error) {
 	tokens, err := GlobalExpandTokenizer.Tokenize(expand)
 
 	if err != nil {
@@ -74,7 +75,7 @@ func ParseExpandString(expand string) (*GoDataExpandQuery, error) {
 		} else if token.Value == "," {
 			if stack.Empty() {
 				// no paren on the stack, parse this item and start a new queue
-				item, err := ParseExpandItem(queue)
+				item, err := ParseExpandItem(ctx, queue)
 				if err != nil {
 					return nil, err
 				}
@@ -93,7 +94,7 @@ func ParseExpandString(expand string) (*GoDataExpandQuery, error) {
 		return nil, BadRequestError("Mismatched parentheses in expand clause.")
 	}
 
-	item, err := ParseExpandItem(queue)
+	item, err := ParseExpandItem(ctx, queue)
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +103,7 @@ func ParseExpandString(expand string) (*GoDataExpandQuery, error) {
 	return &GoDataExpandQuery{ExpandItems: items}, nil
 }
 
-func ParseExpandItem(input tokenQueue) (*ExpandItem, error) {
+func ParseExpandItem(ctx context.Context, input tokenQueue) (*ExpandItem, error) {
 
 	item := &ExpandItem{}
 	item.Path = []*Token{}
@@ -128,7 +129,7 @@ func ParseExpandItem(input tokenQueue) (*ExpandItem, error) {
 				queue.Enqueue(token)
 			} else {
 				// top level slash means we're done parsing the options
-				err := ParseExpandOption(queue, item)
+				err := ParseExpandOption(ctx, queue, item)
 				if err != nil {
 					return nil, err
 				}
@@ -140,7 +141,7 @@ func ParseExpandItem(input tokenQueue) (*ExpandItem, error) {
 			item.Path = append(item.Path, queue.Dequeue())
 		} else if token.Value == ";" && stack.Size == 1 {
 			// semicolons only split expand options at the first level
-			err := ParseExpandOption(queue, item)
+			err := ParseExpandOption(ctx, queue, item)
 			if err != nil {
 				return nil, err
 			}
@@ -162,7 +163,7 @@ func ParseExpandItem(input tokenQueue) (*ExpandItem, error) {
 	return item, nil
 }
 
-func ParseExpandOption(queue *tokenQueue, item *ExpandItem) error {
+func ParseExpandOption(ctx context.Context, queue *tokenQueue, item *ExpandItem) error {
 	head := queue.Dequeue().Value
 	if queue.Head == nil {
 		return BadRequestError("Invalid expand clause.")
@@ -171,7 +172,7 @@ func ParseExpandOption(queue *tokenQueue, item *ExpandItem) error {
 	body := queue.GetValue()
 
 	if head == "$filter" {
-		filter, err := ParseFilterString(body)
+		filter, err := ParseFilterString(ctx, body)
 		if err == nil {
 			item.Filter = filter
 		} else {
@@ -180,7 +181,7 @@ func ParseExpandOption(queue *tokenQueue, item *ExpandItem) error {
 	}
 
 	if head == "at" {
-		at, err := ParseFilterString(body)
+		at, err := ParseFilterString(ctx, body)
 		if err == nil {
 			item.At = at
 		} else {
@@ -189,7 +190,7 @@ func ParseExpandOption(queue *tokenQueue, item *ExpandItem) error {
 	}
 
 	if head == "$search" {
-		search, err := ParseSearchString(body)
+		search, err := ParseSearchString(ctx, body)
 		if err == nil {
 			item.Search = search
 		} else {
@@ -198,7 +199,7 @@ func ParseExpandOption(queue *tokenQueue, item *ExpandItem) error {
 	}
 
 	if head == "$orderby" {
-		orderby, err := ParseOrderByString(body)
+		orderby, err := ParseOrderByString(ctx, body)
 		if err == nil {
 			item.OrderBy = orderby
 		} else {
@@ -207,7 +208,7 @@ func ParseExpandOption(queue *tokenQueue, item *ExpandItem) error {
 	}
 
 	if head == "$skip" {
-		skip, err := ParseSkipString(body)
+		skip, err := ParseSkipString(ctx, body)
 		if err == nil {
 			item.Skip = skip
 		} else {
@@ -216,7 +217,7 @@ func ParseExpandOption(queue *tokenQueue, item *ExpandItem) error {
 	}
 
 	if head == "$top" {
-		top, err := ParseTopString(body)
+		top, err := ParseTopString(ctx, body)
 		if err == nil {
 			item.Top = top
 		} else {
@@ -225,7 +226,7 @@ func ParseExpandOption(queue *tokenQueue, item *ExpandItem) error {
 	}
 
 	if head == "$select" {
-		sel, err := ParseSelectString(body)
+		sel, err := ParseSelectString(ctx, body)
 		if err == nil {
 			item.Select = sel
 		} else {
@@ -234,7 +235,7 @@ func ParseExpandOption(queue *tokenQueue, item *ExpandItem) error {
 	}
 
 	if head == "$expand" {
-		expand, err := ParseExpandString(body)
+		expand, err := ParseExpandString(ctx, body)
 		if err == nil {
 			item.Expand = expand
 		} else {

--- a/expand_parser_test.go
+++ b/expand_parser_test.go
@@ -1,13 +1,14 @@
 package godata
 
 import (
+	"context"
 	"testing"
 )
 
 func TestTrivialExpand(t *testing.T) {
 	input := "Products/Categories"
-
-	output, err := ParseExpandString(input)
+	ctx := context.Background()
+	output, err := ParseExpandString(ctx, input)
 
 	if err != nil {
 		t.Error(err)
@@ -26,8 +27,8 @@ func TestTrivialExpand(t *testing.T) {
 
 func TestSimpleExpand(t *testing.T) {
 	input := "Products($filter=DiscontinuedDate eq null)"
-
-	output, err := ParseExpandString(input)
+	ctx := context.Background()
+	output, err := ParseExpandString(ctx, input)
 
 	if err != nil {
 		t.Error(err)
@@ -57,8 +58,8 @@ func TestSimpleExpand(t *testing.T) {
 
 func TestExpandNestedCommas(t *testing.T) {
 	input := "DirectReports($select=FirstName,LastName;$levels=4)"
-
-	output, err := ParseExpandString(input)
+	ctx := context.Background()
+	output, err := ParseExpandString(ctx, input)
 
 	if err != nil {
 		t.Error(err)
@@ -91,8 +92,8 @@ func TestExpandNestedCommas(t *testing.T) {
 
 func TestExpandNestedParens(t *testing.T) {
 	input := "Products($filter=not (DiscontinuedDate eq null))"
-
-	output, err := ParseExpandString(input)
+	ctx := context.Background()
+	output, err := ParseExpandString(ctx, input)
 
 	if err != nil {
 		t.Error(err)

--- a/expression_parser.go
+++ b/expression_parser.go
@@ -104,8 +104,7 @@ type ExpressionParser struct {
 // ParseExpressionString converts a ODATA expression input string into a parse
 // tree that can be used by providers to create a response.
 // Expressions can be used within $filter and $orderby query options.
-func (p *ExpressionParser) ParseExpressionString(expression string) (*GoDataExpression, error) {
-	ctx := context.Background()
+func (p *ExpressionParser) ParseExpressionString(ctx context.Context, expression string) (*GoDataExpression, error) {
 	tokens, err := p.tokenizer.Tokenize(ctx, expression)
 	if err != nil {
 		return nil, err

--- a/expression_parser.go
+++ b/expression_parser.go
@@ -1,6 +1,7 @@
 package godata
 
 import (
+	"context"
 	"strings"
 )
 
@@ -104,17 +105,17 @@ type ExpressionParser struct {
 // tree that can be used by providers to create a response.
 // Expressions can be used within $filter and $orderby query options.
 func (p *ExpressionParser) ParseExpressionString(expression string) (*GoDataExpression, error) {
-
-	tokens, err := p.tokenizer.Tokenize(expression)
+	ctx := context.Background()
+	tokens, err := p.tokenizer.Tokenize(ctx, expression)
 	if err != nil {
 		return nil, err
 	}
 	// TODO: can we do this in one fell swoop?
-	postfix, err := p.InfixToPostfix(tokens)
+	postfix, err := p.InfixToPostfix(ctx, tokens)
 	if err != nil {
 		return nil, err
 	}
-	tree, err := p.PostfixToTree(postfix)
+	tree, err := p.PostfixToTree(ctx, postfix)
 	if err != nil {
 		return nil, err
 	}

--- a/expression_parser_test.go
+++ b/expression_parser_test.go
@@ -202,11 +202,12 @@ func TestValidBooleanExpressionSyntax(t *testing.T) {
 			"Tags/any(var:var/Key eq 'Site' and var/Value eq 'New York City') or " +
 			"Tags/any(var:var/Key eq 'Site' and var/Value eq 'San Francisco')",
 	}
+	ctx := context.Background()
 	p := NewExpressionParser()
 	p.ExpectBoolExpr = true
 	for _, input := range queries {
 		t.Logf("Testing expression %s", input)
-		q, err := p.ParseExpressionString(input)
+		q, err := p.ParseExpressionString(ctx, input)
 		if err != nil {
 			t.Errorf("Error parsing query '%s'. Error: %v", input, err)
 		} else {
@@ -224,6 +225,7 @@ func TestValidBooleanExpressionSyntax(t *testing.T) {
 
 // The URLs below are not valid ODATA syntax, the parser should return an error.
 func TestInvalidBooleanExpressionSyntax(t *testing.T) {
+	ctx := context.Background()
 	queries := []string{
 		"(TRUE)",  // Should be true lowercase
 		"(City)",  // The literal City is not boolean
@@ -242,10 +244,100 @@ func TestInvalidBooleanExpressionSyntax(t *testing.T) {
 	p := NewExpressionParser()
 	p.ExpectBoolExpr = true
 	for _, input := range queries {
-		q, err := p.ParseExpressionString(input)
+		q, err := p.ParseExpressionString(ctx, input)
 		if err == nil {
 			// The parser has incorrectly determined the syntax is valid.
 			t.Errorf("The expression '%s' is not valid ODATA syntax. The ODATA parser should return an error. Tree:\n%v", input, q.Tree)
+		}
+	}
+}
+
+func TestExpressionWithLenientFlags(t *testing.T) {
+	testCases := []struct {
+		expression string
+		valid      bool // true if parsing expression should be successful.
+		cfg        OdataComplianceConfig
+		setCtx     bool
+		tree       []expectedParseNode // The expected tree.
+	}{
+		{
+			expression: "(a, b, )",
+			valid:      false,
+			setCtx:     false,
+		},
+		{
+			expression: "(a, b, )",
+			valid:      false,
+			setCtx:     true,
+		},
+		{
+			expression: "(a, b, )",
+			valid:      false,
+			setCtx:     true,
+			cfg:        ComplianceStrict,
+		},
+		{
+			expression: "(a, b, )",
+			valid:      true, // Normally this would not be valid, but the ComplianceIgnoreInvalidComma flag is set.
+			setCtx:     true,
+			cfg:        ComplianceIgnoreInvalidComma,
+		},
+		{
+			expression: "City in ('Dallas', 'Houston', )",
+			valid:      true,
+			setCtx:     true,
+			cfg:        ComplianceIgnoreInvalidComma,
+			tree: []expectedParseNode{
+				{Value: "in", Depth: 0, Type: ExpressionTokenLogical},
+				{Value: "City", Depth: 1, Type: ExpressionTokenLiteral},
+				{Value: TokenListExpr, Depth: 1, Type: TokenTypeListExpr},
+				{Value: "'Dallas'", Depth: 2, Type: ExpressionTokenString},
+				{Value: "'Houston'", Depth: 2, Type: ExpressionTokenString},
+			},
+		},
+		{
+			expression: "(a, , b)", // This is not a list.
+			valid:      false,
+		},
+		{
+			expression: "(, a, b)", // This is not a list.
+			valid:      false,
+		},
+		{
+			expression: "(,)", // A comma by itself is not an expression
+			valid:      false,
+		},
+		{
+			expression: "(,)", // A comma by itself is not an expression
+			valid:      false,
+			setCtx:     true,
+			cfg:        ComplianceIgnoreInvalidComma,
+		},
+	}
+
+	p := NewExpressionParser()
+	p.ExpectBoolExpr = false
+	for _, testCase := range testCases {
+		t.Logf("testing: %s", testCase.expression)
+		ctx := context.Background()
+		if testCase.setCtx {
+			ctx = WithOdataComplianceConfig(ctx, testCase.cfg)
+		}
+		q, err := p.ParseExpressionString(ctx, testCase.expression)
+		if testCase.valid && err != nil {
+			// The parser has incorrectly determined the syntax is invalid.
+			t.Errorf("The expression '%s' is valid ODATA syntax. Cfg: %v The ODATA parser should not have returned an error",
+				testCase.expression, testCase.cfg)
+		} else if !testCase.valid && err == nil {
+			// The parser has incorrectly determined the syntax is valid.
+			t.Errorf("The expression '%s' is not valid ODATA syntax. The ODATA parser should return an error. Tree:\n%v",
+				testCase.expression, q.Tree)
+		} else if testCase.valid && testCase.tree != nil {
+			pos := 0
+			err = CompareTree(q.Tree, testCase.tree, &pos, 0)
+			if err != nil {
+				t.Errorf("Tree representation does not match expected value. error: %v. Tree:\n%v", err, q.Tree)
+			}
 		}
 	}
 }
@@ -308,11 +400,12 @@ func TestInvalidExpressionSyntax(t *testing.T) {
 		"a b c",                        // Invalid sequence of literals.
 		"'a' 'b' 'c'",                  // Invalid sequence of strings.
 	}
+	ctx := context.Background()
 	p := NewExpressionParser()
 	p.ExpectBoolExpr = false
 	for _, input := range queries {
 		t.Logf("testing: %s", input)
-		q, err := p.ParseExpressionString(input)
+		q, err := p.ParseExpressionString(ctx, input)
 		if err == nil {
 			// The parser has incorrectly determined the syntax is valid.
 			t.Errorf("The expression '%s' is not valid ODATA syntax. The ODATA parser should return an error. Tree:\n%v", input, q.Tree)

--- a/expression_parser_test.go
+++ b/expression_parser_test.go
@@ -1,6 +1,7 @@
 package godata
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
@@ -14,6 +15,7 @@ func TestTokenTypes(t *testing.T) {
 }
 
 func TestExpressionDateTime(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	tokens := map[string]ExpressionTokenType{
 		"2011-08-29T21:58Z":             ExpressionTokenDateTime,
@@ -40,7 +42,7 @@ func TestExpressionDateTime(t *testing.T) {
 			{Value: "gt", Type: ExpressionTokenLogical},
 			{Value: tokenValue, Type: tokenType},
 		}
-		output, err := tokenizer.Tokenize(input)
+		output, err := tokenizer.Tokenize(ctx, input)
 		if err != nil {
 			t.Errorf("Failed to tokenize input %s. Error: %v", input, err)
 		}
@@ -319,10 +321,11 @@ func TestInvalidExpressionSyntax(t *testing.T) {
 }
 
 func BenchmarkExpressionTokenizer(b *testing.B) {
+	ctx := context.Background()
 	t := NewExpressionTokenizer()
 	for i := 0; i < b.N; i++ {
 		input := "Name eq 'Milk' and Price lt 2.55"
-		if _, err := t.Tokenize(input); err != nil {
+		if _, err := t.Tokenize(ctx, input); err != nil {
 			b.Fatalf("Failed to tokenize expression: %v", err)
 		}
 	}
@@ -432,11 +435,11 @@ func CompareTree(node *ParseNode, expect []expectedParseNode, pos *int, level in
 }
 
 func TestExpressions(t *testing.T) {
-
+	ctx := context.Background()
 	p := NewExpressionParser()
 	for _, testCase := range testCases {
 		t.Logf("Expression: %s", testCase.expression)
-		tokens, err := GlobalExpressionTokenizer.Tokenize(testCase.expression)
+		tokens, err := GlobalExpressionTokenizer.Tokenize(ctx, testCase.expression)
 		if err != nil {
 			t.Errorf("Failed to tokenize expression '%s'. Error: %v", testCase.expression, err)
 			continue
@@ -447,7 +450,7 @@ func TestExpressions(t *testing.T) {
 				continue
 			}
 		}
-		output, err := p.InfixToPostfix(tokens)
+		output, err := p.InfixToPostfix(ctx, tokens)
 		if err != nil {
 			t.Errorf("Failed to convert expression to postfix notation: %v", err)
 			continue
@@ -458,7 +461,7 @@ func TestExpressions(t *testing.T) {
 				continue
 			}
 		}
-		tree, err := p.PostfixToTree(output)
+		tree, err := p.PostfixToTree(ctx, output)
 		if err != nil {
 			t.Errorf("Failed to parse expression '%s'. Error: %v", testCase.expression, err)
 			continue

--- a/filter_parser.go
+++ b/filter_parser.go
@@ -8,16 +8,16 @@ var GlobalFilterParser = NewExpressionParser()
 // ParseFilterString converts an input string from the $filter part of the URL into a parse
 // tree that can be used by providers to create a response.
 func ParseFilterString(ctx context.Context, filter string) (*GoDataFilterQuery, error) {
-	tokens, err := GlobalFilterTokenizer.Tokenize(filter)
+	tokens, err := GlobalFilterTokenizer.Tokenize(ctx, filter)
 	if err != nil {
 		return nil, err
 	}
 	// TODO: can we do this in one fell swoop?
-	postfix, err := GlobalFilterParser.InfixToPostfix(tokens)
+	postfix, err := GlobalFilterParser.InfixToPostfix(ctx, tokens)
 	if err != nil {
 		return nil, err
 	}
-	tree, err := GlobalFilterParser.PostfixToTree(postfix)
+	tree, err := GlobalFilterParser.PostfixToTree(ctx, postfix)
 	if err != nil {
 		return nil, err
 	}

--- a/filter_parser.go
+++ b/filter_parser.go
@@ -1,11 +1,13 @@
 package godata
 
+import "context"
+
 var GlobalFilterTokenizer = NewExpressionTokenizer()
 var GlobalFilterParser = NewExpressionParser()
 
 // ParseFilterString converts an input string from the $filter part of the URL into a parse
 // tree that can be used by providers to create a response.
-func ParseFilterString(filter string) (*GoDataFilterQuery, error) {
+func ParseFilterString(ctx context.Context, filter string) (*GoDataFilterQuery, error) {
 	tokens, err := GlobalFilterTokenizer.Tokenize(filter)
 	if err != nil {
 		return nil, err

--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -1,6 +1,7 @@
 package godata
 
 import (
+	"context"
 	"strings"
 	"testing"
 )
@@ -108,7 +109,8 @@ func TestFilterAnyArrayOfPrimitiveTypes(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	q, err := ParseFilterString(input)
+	ctx := context.Background()
+	q, err := ParseFilterString(ctx, input)
 	if err != nil {
 		t.Errorf("Error parsing query %s. Error: %v", input, err)
 		return
@@ -230,7 +232,8 @@ func TestFilterAnyMixedQuery(t *testing.T) {
 	// Other path expressions in the Boolean expression neither prefixed with the lambda variable nor $it are evaluated in the scope of
 	// the collection instances at the origin of the navigation path prepended to the lambda operator.
 	input := "Tags/any(d:d eq 'Site' or 'Environment' eq d/Key or d/d/d eq 123456 or concat(d/FirstName, d/LastName) eq $it/FullName)"
-	q, err := ParseFilterString(input)
+	ctx := context.Background()
+	q, err := ParseFilterString(ctx, input)
 	if err != nil {
 		t.Errorf("Error parsing query %s. Error: %v", input, err)
 		return
@@ -358,7 +361,8 @@ func TestFilterAnyWithNoArgs(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	q, err := ParseFilterString(input)
+	ctx := context.Background()
+	q, err := ParseFilterString(ctx, input)
 	if err != nil {
 		t.Errorf("Error parsing query %s. Error: %v", input, err)
 		return
@@ -434,7 +438,8 @@ func TestFilterNotBooleanProperty(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	q, err := ParseFilterString(input)
+	ctx := context.Background()
+	q, err := ParseFilterString(ctx, input)
 	if err != nil {
 		t.Errorf("Error parsing query %s. Error: %v", input, err)
 		return
@@ -492,8 +497,8 @@ func TestFilterNotWithNoSpace(t *testing.T) {
 			t.Error(err)
 		}
 	}
-
-	q, err := ParseFilterString(input)
+	ctx := context.Background()
+	q, err := ParseFilterString(ctx, input)
 	if err != nil {
 		t.Errorf("Error parsing query %s. Error: %v", input, err)
 		return
@@ -823,7 +828,8 @@ func TestFilterInOperatorWithFunc(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	q, err := ParseFilterString(input)
+	ctx := context.Background()
+	q, err := ParseFilterString(ctx, input)
 	if err != nil {
 		t.Fatalf("Error parsing filter: %v", err)
 	}
@@ -1232,8 +1238,9 @@ func TestValidFilterSyntax(t *testing.T) {
 			"Tags/any(var:var/Key eq 'Site' and var/Value eq 'New York City') or " +
 			"Tags/any(var:var/Key eq 'Site' and var/Value eq 'San Francisco')",
 	}
+	ctx := context.Background()
 	for _, input := range queries {
-		q, err := ParseFilterString(input)
+		q, err := ParseFilterString(ctx, input)
 		if err != nil {
 			t.Errorf("Error parsing query %s. Error: %v", input, err)
 			return
@@ -1307,8 +1314,9 @@ func TestInvalidFilterSyntax(t *testing.T) {
 		"numCore neq 12",               // Invalid operator. It should be 'ne'
 		//"contains(Name, 'a', 'b', 'c', 'd')", // Too many function arguments
 	}
+	ctx := context.Background()
 	for _, input := range queries {
-		q, err := ParseFilterString(input)
+		q, err := ParseFilterString(ctx, input)
 		if err == nil {
 			// The parser has incorrectly determined the syntax is valid.
 			t.Errorf("The query '$filter=%s' is not valid ODATA syntax. The ODATA parser should return an error. Tree:\n%v", input, q.Tree)
@@ -1932,7 +1940,8 @@ func TestFilterLambdaAnyAnd(t *testing.T) {
 
 func TestFilterLambdaNestedAny(t *testing.T) {
 	input := "Enabled/any(t:t/Value eq Config/any(c:c/AdminState eq 'TRUE'))"
-	q, err := ParseFilterString(input)
+	ctx := context.Background()
+	q, err := ParseFilterString(ctx, input)
 	if err != nil {
 		t.Errorf("Error parsing query %s. Error: %v", input, err)
 		return

--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestFilterDateTime(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	tokens := map[string]TokenType{
 		"2011-08-29T21:58Z":             ExpressionTokenDateTime,
@@ -33,7 +34,7 @@ func TestFilterDateTime(t *testing.T) {
 			{Value: "gt", Type: ExpressionTokenLogical},
 			{Value: tokenValue, Type: tokenType},
 		}
-		output, err := tokenizer.Tokenize(input)
+		output, err := tokenizer.Tokenize(ctx, input)
 		if err != nil {
 			t.Errorf("Failed to tokenize input %s. Error: %v", input, err)
 		}
@@ -50,6 +51,7 @@ func TestFilterDateTime(t *testing.T) {
 }
 
 func TestFilterAnyArrayOfObjects(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	input := "Tags/any(d:d/Key eq 'Site' and d/Value lt 10)"
 	expect := []*Token{
@@ -72,7 +74,7 @@ func TestFilterAnyArrayOfObjects(t *testing.T) {
 		{Value: "10", Type: ExpressionTokenInteger},
 		{Value: ")", Type: ExpressionTokenCloseParen},
 	}
-	output, err := tokenizer.Tokenize(input)
+	output, err := tokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 	}
@@ -84,6 +86,7 @@ func TestFilterAnyArrayOfObjects(t *testing.T) {
 }
 
 func TestFilterAnyArrayOfPrimitiveTypes(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	input := "Tags/any(d:d eq 'Site')"
 	{
@@ -99,7 +102,7 @@ func TestFilterAnyArrayOfPrimitiveTypes(t *testing.T) {
 			{Value: "'Site'", Type: ExpressionTokenString},
 			{Value: ")", Type: ExpressionTokenCloseParen},
 		}
-		output, err := tokenizer.Tokenize(input)
+		output, err := tokenizer.Tokenize(ctx, input)
 		if err != nil {
 			t.Error(err)
 		}
@@ -109,7 +112,6 @@ func TestFilterAnyArrayOfPrimitiveTypes(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	ctx := context.Background()
 	q, err := ParseFilterString(ctx, input)
 	if err != nil {
 		t.Errorf("Error parsing query %s. Error: %v", input, err)
@@ -281,6 +283,7 @@ func TestFilterAnyMixedQuery(t *testing.T) {
 }
 
 func TestFilterGuid(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	input := "GuidValue eq 01234567-89ab-cdef-0123-456789abcdef"
 
@@ -289,7 +292,7 @@ func TestFilterGuid(t *testing.T) {
 		{Value: "eq", Type: ExpressionTokenLogical},
 		{Value: "01234567-89ab-cdef-0123-456789abcdef", Type: ExpressionTokenGuid},
 	}
-	output, err := tokenizer.Tokenize(input)
+	output, err := tokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 	}
@@ -300,6 +303,7 @@ func TestFilterGuid(t *testing.T) {
 }
 
 func TestFilterDurationWithType(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	input := "Task eq duration'P12DT23H59M59.999999999999S'"
 
@@ -309,7 +313,7 @@ func TestFilterDurationWithType(t *testing.T) {
 		// Note the duration token is extracted.
 		{Value: "P12DT23H59M59.999999999999S", Type: ExpressionTokenDuration},
 	}
-	output, err := tokenizer.Tokenize(input)
+	output, err := tokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 	}
@@ -321,6 +325,7 @@ func TestFilterDurationWithType(t *testing.T) {
 }
 
 func TestFilterDurationWithoutType(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	input := "Task eq 'P12DT23H59M59.999999999999S'"
 
@@ -329,7 +334,7 @@ func TestFilterDurationWithoutType(t *testing.T) {
 		{Value: "eq", Type: ExpressionTokenLogical},
 		{Value: "P12DT23H59M59.999999999999S", Type: ExpressionTokenDuration},
 	}
-	output, err := tokenizer.Tokenize(input)
+	output, err := tokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 	}
@@ -341,6 +346,7 @@ func TestFilterDurationWithoutType(t *testing.T) {
 }
 
 func TestFilterAnyWithNoArgs(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	input := "Tags/any()"
 	{
@@ -351,7 +357,7 @@ func TestFilterAnyWithNoArgs(t *testing.T) {
 			{Value: "(", Type: ExpressionTokenOpenParen},
 			{Value: ")", Type: ExpressionTokenCloseParen},
 		}
-		output, err := tokenizer.Tokenize(input)
+		output, err := tokenizer.Tokenize(ctx, input)
 		if err != nil {
 			t.Error(err)
 		}
@@ -361,7 +367,6 @@ func TestFilterAnyWithNoArgs(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	ctx := context.Background()
 	q, err := ParseFilterString(ctx, input)
 	if err != nil {
 		t.Errorf("Error parsing query %s. Error: %v", input, err)
@@ -379,6 +384,7 @@ func TestFilterAnyWithNoArgs(t *testing.T) {
 	}
 }
 func TestFilterDivby(t *testing.T) {
+	ctx := context.Background()
 	{
 		tokenizer := NewExpressionTokenizer()
 		input := "Price div 2 gt 3.5"
@@ -389,7 +395,7 @@ func TestFilterDivby(t *testing.T) {
 			{Value: "gt", Type: ExpressionTokenLogical},
 			{Value: "3.5", Type: ExpressionTokenFloat},
 		}
-		output, err := tokenizer.Tokenize(input)
+		output, err := tokenizer.Tokenize(ctx, input)
 		if err != nil {
 			t.Error(err)
 		}
@@ -409,7 +415,7 @@ func TestFilterDivby(t *testing.T) {
 			{Value: "gt", Type: ExpressionTokenLogical},
 			{Value: "3.5", Type: ExpressionTokenFloat},
 		}
-		output, err := tokenizer.Tokenize(input)
+		output, err := tokenizer.Tokenize(ctx, input)
 		if err != nil {
 			t.Error(err)
 		}
@@ -422,6 +428,7 @@ func TestFilterDivby(t *testing.T) {
 }
 
 func TestFilterNotBooleanProperty(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	input := "not Enabled"
 	{
@@ -429,7 +436,7 @@ func TestFilterNotBooleanProperty(t *testing.T) {
 			{Value: "not", Type: ExpressionTokenLogical},
 			{Value: "Enabled", Type: ExpressionTokenLiteral},
 		}
-		output, err := tokenizer.Tokenize(input)
+		output, err := tokenizer.Tokenize(ctx, input)
 		if err != nil {
 			t.Error(err)
 		}
@@ -438,7 +445,6 @@ func TestFilterNotBooleanProperty(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	ctx := context.Background()
 	q, err := ParseFilterString(ctx, input)
 	if err != nil {
 		t.Errorf("Error parsing query %s. Error: %v", input, err)
@@ -457,6 +463,7 @@ func TestFilterNotBooleanProperty(t *testing.T) {
 }
 
 func TestFilterEmptyStringToken(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	input := "City eq ''"
 	expect := []*Token{
@@ -464,7 +471,7 @@ func TestFilterEmptyStringToken(t *testing.T) {
 		{Value: "eq", Type: ExpressionTokenLogical},
 		{Value: "''", Type: ExpressionTokenString},
 	}
-	output, err := tokenizer.Tokenize(input)
+	output, err := tokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 	}
@@ -477,6 +484,7 @@ func TestFilterEmptyStringToken(t *testing.T) {
 // Note: according to ODATA ABNF notation, there must be a space between not and open parenthesis.
 // http://docs.oasis-open.org/odata/odata/v4.01/csprd03/abnf/odata-abnf-construction-rules.txt
 func TestFilterNotWithNoSpace(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	input := "not(City eq 'Seattle')"
 	{
@@ -488,7 +496,7 @@ func TestFilterNotWithNoSpace(t *testing.T) {
 			{Value: "'Seattle'", Type: ExpressionTokenString},
 			{Value: ")", Type: ExpressionTokenCloseParen},
 		}
-		output, err := tokenizer.Tokenize(input)
+		output, err := tokenizer.Tokenize(ctx, input)
 		if err != nil {
 			t.Error(err)
 		}
@@ -497,7 +505,7 @@ func TestFilterNotWithNoSpace(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	ctx := context.Background()
+
 	q, err := ParseFilterString(ctx, input)
 	if err != nil {
 		t.Errorf("Error parsing query %s. Error: %v", input, err)
@@ -518,6 +526,7 @@ func TestFilterNotWithNoSpace(t *testing.T) {
 
 // TestFilterInOperator tests the "IN" operator with a comma-separated list of values.
 func TestFilterInOperator(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	input := "City in ( 'Seattle', 'Atlanta', 'Paris' )"
 
@@ -532,7 +541,7 @@ func TestFilterInOperator(t *testing.T) {
 		{Value: "'Paris'", Type: ExpressionTokenString},
 		{Value: ")", Type: ExpressionTokenCloseParen},
 	}
-	tokens, err := tokenizer.Tokenize(input)
+	tokens, err := tokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 	}
@@ -541,7 +550,7 @@ func TestFilterInOperator(t *testing.T) {
 		t.Error(err)
 	}
 	var postfix *tokenQueue
-	postfix, err = GlobalFilterParser.InfixToPostfix(tokens)
+	postfix, err = GlobalFilterParser.InfixToPostfix(ctx, tokens)
 	if err != nil {
 		t.Error(err)
 	}
@@ -558,7 +567,7 @@ func TestFilterInOperator(t *testing.T) {
 		t.Error(err)
 	}
 
-	tree, err := GlobalFilterParser.PostfixToTree(postfix)
+	tree, err := GlobalFilterParser.PostfixToTree(ctx, postfix)
 	if err != nil {
 		t.Error(err)
 	}
@@ -580,6 +589,7 @@ func TestFilterInOperator(t *testing.T) {
 
 // TestFilterInOperatorSingleValue tests the "IN" operator with a list containing a single value.
 func TestFilterInOperatorSingleValue(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	input := "City in ( 'Seattle' )"
 
@@ -590,7 +600,7 @@ func TestFilterInOperatorSingleValue(t *testing.T) {
 		{Value: "'Seattle'", Type: ExpressionTokenString},
 		{Value: ")", Type: ExpressionTokenCloseParen},
 	}
-	tokens, err := tokenizer.Tokenize(input)
+	tokens, err := tokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 	}
@@ -599,7 +609,7 @@ func TestFilterInOperatorSingleValue(t *testing.T) {
 		t.Error(err)
 	}
 	var postfix *tokenQueue
-	postfix, err = GlobalFilterParser.InfixToPostfix(tokens)
+	postfix, err = GlobalFilterParser.InfixToPostfix(ctx, tokens)
 	if err != nil {
 		t.Error(err)
 	}
@@ -614,7 +624,7 @@ func TestFilterInOperatorSingleValue(t *testing.T) {
 		t.Error(err)
 	}
 
-	tree, err := GlobalFilterParser.PostfixToTree(postfix)
+	tree, err := GlobalFilterParser.PostfixToTree(ctx, postfix)
 	if err != nil {
 		t.Error(err)
 	}
@@ -634,6 +644,7 @@ func TestFilterInOperatorSingleValue(t *testing.T) {
 
 // TestFilterInOperatorEmptyList tests the "IN" operator with a list containing no value.
 func TestFilterInOperatorEmptyList(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	input := "City in ( )"
 
@@ -643,7 +654,7 @@ func TestFilterInOperatorEmptyList(t *testing.T) {
 		{Value: "(", Type: ExpressionTokenOpenParen},
 		{Value: ")", Type: ExpressionTokenCloseParen},
 	}
-	tokens, err := tokenizer.Tokenize(input)
+	tokens, err := tokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -652,7 +663,7 @@ func TestFilterInOperatorEmptyList(t *testing.T) {
 		t.Fatal(err)
 	}
 	var postfix *tokenQueue
-	postfix, err = GlobalFilterParser.InfixToPostfix(tokens)
+	postfix, err = GlobalFilterParser.InfixToPostfix(ctx, tokens)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -666,7 +677,7 @@ func TestFilterInOperatorEmptyList(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tree, err := GlobalFilterParser.PostfixToTree(postfix)
+	tree, err := GlobalFilterParser.PostfixToTree(ctx, postfix)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -688,6 +699,7 @@ func TestFilterInOperatorEmptyList(t *testing.T) {
 //   listExpr  = OPEN BWS commonExpr BWS *( COMMA BWS commonExpr BWS ) CLOSE
 // Validate if a list is within another list.
 func TestFilterInOperatorBothSides(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	input := "(1, 2) in ( ('ab', 'cd'), (1, 2), ('abc', 'def') )"
 
@@ -721,7 +733,7 @@ func TestFilterInOperatorBothSides(t *testing.T) {
 		{Value: ")", Type: ExpressionTokenCloseParen},
 		{Value: ")", Type: ExpressionTokenCloseParen},
 	}
-	tokens, err := tokenizer.Tokenize(input)
+	tokens, err := tokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -730,7 +742,7 @@ func TestFilterInOperatorBothSides(t *testing.T) {
 		t.Fatal(err)
 	}
 	var postfix *tokenQueue
-	postfix, err = GlobalFilterParser.InfixToPostfix(tokens)
+	postfix, err = GlobalFilterParser.InfixToPostfix(ctx, tokens)
 	if err != nil {
 		t.Fatalf("failed to convert from infix to postfix: %v", err)
 	}
@@ -764,7 +776,7 @@ func TestFilterInOperatorBothSides(t *testing.T) {
 		t.Fatalf("Unexpected postfix notation: %v. Error: %v", postfix, err)
 	}
 
-	tree, err := GlobalFilterParser.PostfixToTree(postfix)
+	tree, err := GlobalFilterParser.PostfixToTree(ctx, postfix)
 	if err != nil {
 		t.Fatalf("Failed to convert postfix to tree: %v", err)
 	}
@@ -796,6 +808,7 @@ func TestFilterInOperatorBothSides(t *testing.T) {
 // TestFilterInOperatorWithFunc tests the "IN" operator with a comma-separated list
 // of values, one of which is a function call which itself has a comma-separated list of values.
 func TestFilterInOperatorWithFunc(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	// 'Atlanta' is enclosed in a unecessary parenExpr to validate the expression is properly unwrapped.
 	input := "City in ( 'Seattle', concat('San', 'Francisco'), ('Atlanta') )"
@@ -819,7 +832,7 @@ func TestFilterInOperatorWithFunc(t *testing.T) {
 			{Value: ")", Type: ExpressionTokenCloseParen},
 			{Value: ")", Type: ExpressionTokenCloseParen},
 		}
-		output, err := tokenizer.Tokenize(input)
+		output, err := tokenizer.Tokenize(ctx, input)
 		if err != nil {
 			t.Error(err)
 		}
@@ -828,7 +841,6 @@ func TestFilterInOperatorWithFunc(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	ctx := context.Background()
 	q, err := ParseFilterString(ctx, input)
 	if err != nil {
 		t.Fatalf("Error parsing filter: %v", err)
@@ -851,6 +863,7 @@ func TestFilterInOperatorWithFunc(t *testing.T) {
 }
 
 func TestFilterNotInListExpr(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	input := "not ( City in ( 'Seattle', 'Atlanta' ) )"
 
@@ -867,7 +880,7 @@ func TestFilterNotInListExpr(t *testing.T) {
 			{Value: ")", Type: ExpressionTokenCloseParen},
 			{Value: ")", Type: ExpressionTokenCloseParen},
 		}
-		output, err := tokenizer.Tokenize(input)
+		output, err := tokenizer.Tokenize(ctx, input)
 		if err != nil {
 			t.Error(err)
 		}
@@ -877,18 +890,18 @@ func TestFilterNotInListExpr(t *testing.T) {
 		}
 	}
 	{
-		tokens, err := GlobalExpressionTokenizer.Tokenize(input)
+		tokens, err := GlobalExpressionTokenizer.Tokenize(ctx, input)
 		if err != nil {
 			t.Error(err)
 			return
 		}
-		output, err := GlobalFilterParser.InfixToPostfix(tokens)
+		output, err := GlobalFilterParser.InfixToPostfix(ctx, tokens)
 		if err != nil {
 			t.Error(err)
 			return
 		}
 
-		tree, err := GlobalFilterParser.PostfixToTree(output)
+		tree, err := GlobalFilterParser.PostfixToTree(ctx, output)
 		if err != nil {
 			t.Error(err)
 			return
@@ -911,6 +924,7 @@ func TestFilterNotInListExpr(t *testing.T) {
 }
 
 func TestFilterAll(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	input := "Tags/all(d:d/Key eq 'Site')"
 	expect := []*Token{
@@ -927,7 +941,7 @@ func TestFilterAll(t *testing.T) {
 		{Value: "'Site'", Type: ExpressionTokenString},
 		{Value: ")", Type: ExpressionTokenCloseParen},
 	}
-	output, err := tokenizer.Tokenize(input)
+	output, err := tokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 	}
@@ -939,7 +953,7 @@ func TestFilterAll(t *testing.T) {
 }
 
 func TestExpressionTokenizer(t *testing.T) {
-
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	input := "Name eq 'Milk' and Price lt 2.55"
 	expect := []*Token{
@@ -951,7 +965,7 @@ func TestExpressionTokenizer(t *testing.T) {
 		{Value: "lt", Type: ExpressionTokenLogical},
 		{Value: "2.55", Type: ExpressionTokenFloat},
 	}
-	output, err := tokenizer.Tokenize(input)
+	output, err := tokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 	}
@@ -963,6 +977,7 @@ func TestExpressionTokenizer(t *testing.T) {
 }
 
 func TestFilterFunction(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	// The syntax for ODATA functions follows the inline parameter syntax. The function name must be followed
 	// by an opening parenthesis, followed by a comma-separated list of parameters, followed by a closing parenthesis.
@@ -986,7 +1001,7 @@ func TestFilterFunction(t *testing.T) {
 		{Value: "'Houston'", Type: ExpressionTokenString},
 	}
 	{
-		output, err := tokenizer.Tokenize(input)
+		output, err := tokenizer.Tokenize(ctx, input)
 		if err != nil {
 			t.Error(err)
 		}
@@ -996,17 +1011,17 @@ func TestFilterFunction(t *testing.T) {
 		}
 	}
 	{
-		tokens, err := GlobalExpressionTokenizer.Tokenize(input)
+		tokens, err := GlobalExpressionTokenizer.Tokenize(ctx, input)
 		if err != nil {
 			t.Error(err)
 			return
 		}
-		output, err := GlobalFilterParser.InfixToPostfix(tokens)
+		output, err := GlobalFilterParser.InfixToPostfix(ctx, tokens)
 		if err != nil {
 			t.Error(err)
 			return
 		}
-		tree, err := GlobalFilterParser.PostfixToTree(output)
+		tree, err := GlobalFilterParser.PostfixToTree(ctx, output)
 		if err != nil {
 			t.Error(err)
 			return
@@ -1033,6 +1048,7 @@ func TestFilterFunction(t *testing.T) {
 }
 
 func TestFilterNestedFunction(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	// Test ODATA syntax with nested function calls
 	input := "contains(LastName, toupper('Smith')) or FirstName eq 'John'"
@@ -1052,7 +1068,7 @@ func TestFilterNestedFunction(t *testing.T) {
 		{Value: "'John'", Type: ExpressionTokenString},
 	}
 	{
-		output, err := tokenizer.Tokenize(input)
+		output, err := tokenizer.Tokenize(ctx, input)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1062,17 +1078,17 @@ func TestFilterNestedFunction(t *testing.T) {
 		}
 	}
 	{
-		tokens, err := GlobalExpressionTokenizer.Tokenize(input)
+		tokens, err := GlobalExpressionTokenizer.Tokenize(ctx, input)
 		if err != nil {
 			t.Error(err)
 			return
 		}
-		output, err := GlobalFilterParser.InfixToPostfix(tokens)
+		output, err := GlobalFilterParser.InfixToPostfix(ctx, tokens)
 		if err != nil {
 			t.Error(err)
 			return
 		}
-		tree, err := GlobalFilterParser.PostfixToTree(output)
+		tree, err := GlobalFilterParser.PostfixToTree(ctx, output)
 		if err != nil {
 			t.Error(err)
 			return
@@ -1327,6 +1343,7 @@ func TestInvalidFilterSyntax(t *testing.T) {
 // See http://docs.oasis-open.org/odata/odata/v4.01/csprd02/part1-protocol/odata-v4.01-csprd02-part1-protocol.html#_Toc486263411
 // Test 'in', which is the 'Is a member of' operator.
 func TestFilterIn(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	input := "contains(LastName, 'Smith') and Site in ('London', 'Paris', 'San Francisco', 'Dallas') and FirstName eq 'John'"
 	expect := []*Token{
@@ -1354,7 +1371,7 @@ func TestFilterIn(t *testing.T) {
 		{Value: "'John'", Type: ExpressionTokenString},
 	}
 	{
-		output, err := tokenizer.Tokenize(input)
+		output, err := tokenizer.Tokenize(ctx, input)
 		if err != nil {
 			t.Error(err)
 		}
@@ -1364,17 +1381,17 @@ func TestFilterIn(t *testing.T) {
 		}
 	}
 	{
-		tokens, err := GlobalExpressionTokenizer.Tokenize(input)
+		tokens, err := GlobalExpressionTokenizer.Tokenize(ctx, input)
 		if err != nil {
 			t.Error(err)
 			return
 		}
-		output, err := GlobalFilterParser.InfixToPostfix(tokens)
+		output, err := GlobalFilterParser.InfixToPostfix(ctx, tokens)
 		if err != nil {
 			t.Error(err)
 			return
 		}
-		tree, err := GlobalFilterParser.PostfixToTree(output)
+		tree, err := GlobalFilterParser.PostfixToTree(ctx, output)
 		if err != nil {
 			t.Error(err)
 			return
@@ -1440,7 +1457,7 @@ func TestFilterIn(t *testing.T) {
 }
 
 func TestExpressionTokenizerFunc(t *testing.T) {
-
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	input := "not endswith(Name,'ilk')"
 	expect := []*Token{
@@ -1452,7 +1469,7 @@ func TestExpressionTokenizerFunc(t *testing.T) {
 		{Value: "'ilk'", Type: ExpressionTokenString},
 		{Value: ")", Type: ExpressionTokenCloseParen},
 	}
-	output, err := tokenizer.Tokenize(input)
+	output, err := tokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 	}
@@ -1464,32 +1481,33 @@ func TestExpressionTokenizerFunc(t *testing.T) {
 }
 
 func BenchmarkFilterTokenizer(b *testing.B) {
+	ctx := context.Background()
 	t := NewExpressionTokenizer()
 	for i := 0; i < b.N; i++ {
 		input := "Name eq 'Milk' and Price lt 2.55"
-		if _, err := t.Tokenize(input); err != nil {
+		if _, err := t.Tokenize(ctx, input); err != nil {
 			b.Fatalf("Failed to tokenize filter: %v", err)
 		}
 	}
 }
 
 func TestFilterParserTree(t *testing.T) {
-
+	ctx := context.Background()
 	input := "not (A eq B)"
 
-	tokens, err := GlobalExpressionTokenizer.Tokenize(input)
+	tokens, err := GlobalExpressionTokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	output, err := GlobalFilterParser.InfixToPostfix(tokens)
+	output, err := GlobalFilterParser.InfixToPostfix(ctx, tokens)
 
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	tree, err := GlobalFilterParser.PostfixToTree(output)
+	tree, err := GlobalFilterParser.PostfixToTree(ctx, output)
 
 	if err != nil {
 		t.Error(err)
@@ -1506,19 +1524,20 @@ func TestFilterParserTree(t *testing.T) {
 }
 
 func TestFilterNestedPath(t *testing.T) {
+	ctx := context.Background()
 	input := "Address/City eq 'Redmond'"
-	tokens, err := GlobalExpressionTokenizer.Tokenize(input)
+	tokens, err := GlobalExpressionTokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	output, err := GlobalFilterParser.InfixToPostfix(tokens)
+	output, err := GlobalFilterParser.InfixToPostfix(ctx, tokens)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	tree, err := GlobalFilterParser.PostfixToTree(output)
+	tree, err := GlobalFilterParser.PostfixToTree(ctx, output)
 	if err != nil {
 		t.Error(err)
 		return
@@ -1539,19 +1558,20 @@ func TestFilterNestedPath(t *testing.T) {
 }
 
 func TestFilterMultipleNestedPath(t *testing.T) {
+	ctx := context.Background()
 	input := "Product/Address/City eq 'Redmond'"
-	tokens, err := GlobalExpressionTokenizer.Tokenize(input)
+	tokens, err := GlobalExpressionTokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	output, err := GlobalFilterParser.InfixToPostfix(tokens)
+	output, err := GlobalFilterParser.InfixToPostfix(ctx, tokens)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	tree, err := GlobalFilterParser.PostfixToTree(output)
+	tree, err := GlobalFilterParser.PostfixToTree(ctx, output)
 	if err != nil {
 		t.Error(err)
 		return
@@ -1574,20 +1594,21 @@ func TestFilterMultipleNestedPath(t *testing.T) {
 }
 
 func TestFilterSubstringFunction(t *testing.T) {
+	ctx := context.Background()
 	// substring can take 2 or 3 arguments.
 	{
 		input := "substring(CompanyName,1) eq 'Foo'"
-		tokens, err := GlobalExpressionTokenizer.Tokenize(input)
+		tokens, err := GlobalExpressionTokenizer.Tokenize(ctx, input)
 		if err != nil {
 			t.Error(err)
 			return
 		}
-		output, err := GlobalFilterParser.InfixToPostfix(tokens)
+		output, err := GlobalFilterParser.InfixToPostfix(ctx, tokens)
 		if err != nil {
 			t.Error(err)
 			return
 		}
-		tree, err := GlobalFilterParser.PostfixToTree(output)
+		tree, err := GlobalFilterParser.PostfixToTree(ctx, output)
 		if err != nil {
 			t.Error(err)
 			return
@@ -1607,17 +1628,17 @@ func TestFilterSubstringFunction(t *testing.T) {
 	}
 	{
 		input := "substring(CompanyName,1,2) eq 'lf'"
-		tokens, err := GlobalExpressionTokenizer.Tokenize(input)
+		tokens, err := GlobalExpressionTokenizer.Tokenize(ctx, input)
 		if err != nil {
 			t.Error(err)
 			return
 		}
-		output, err := GlobalFilterParser.InfixToPostfix(tokens)
+		output, err := GlobalFilterParser.InfixToPostfix(ctx, tokens)
 		if err != nil {
 			t.Error(err)
 			return
 		}
-		tree, err := GlobalFilterParser.PostfixToTree(output)
+		tree, err := GlobalFilterParser.PostfixToTree(ctx, output)
 		if err != nil {
 			t.Error(err)
 			return
@@ -1639,9 +1660,10 @@ func TestFilterSubstringFunction(t *testing.T) {
 }
 
 func TestFilterSubstringofFunction(t *testing.T) {
+	ctx := context.Background()
 	// Previously, the parser was incorrectly interpreting the 'substringof' function as the 'sub' operator.
 	input := "substringof('Alfreds', CompanyName) eq true"
-	tokens, err := GlobalExpressionTokenizer.Tokenize(input)
+	tokens, err := GlobalExpressionTokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 		return
@@ -1662,7 +1684,7 @@ func TestFilterSubstringofFunction(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	output, err := GlobalFilterParser.InfixToPostfix(tokens)
+	output, err := GlobalFilterParser.InfixToPostfix(ctx, tokens)
 	if err != nil {
 		t.Error(err)
 		return
@@ -1681,7 +1703,7 @@ func TestFilterSubstringofFunction(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	tree, err := GlobalFilterParser.PostfixToTree(output)
+	tree, err := GlobalFilterParser.PostfixToTree(ctx, output)
 	if err != nil {
 		t.Error(err)
 		return
@@ -1703,9 +1725,10 @@ func TestFilterSubstringofFunction(t *testing.T) {
 // TestSubstringNestedFunction tests the substring function with a nested call
 // to substring, with the use of 2-argument and 3-argument substring.
 func TestFilterSubstringNestedFunction(t *testing.T) {
+	ctx := context.Background()
 	// Previously, the parser was incorrectly interpreting the 'substringof' function as the 'sub' operator.
 	input := "substring(substring('Francisco', 1), 3, 2) eq 'ci'"
-	tokens, err := GlobalExpressionTokenizer.Tokenize(input)
+	tokens, err := GlobalExpressionTokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 		return
@@ -1733,7 +1756,7 @@ func TestFilterSubstringNestedFunction(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	output, err := GlobalFilterParser.InfixToPostfix(tokens)
+	output, err := GlobalFilterParser.InfixToPostfix(ctx, tokens)
 	if err != nil {
 		t.Error(err)
 		return
@@ -1757,7 +1780,7 @@ func TestFilterSubstringNestedFunction(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	tree, err := GlobalFilterParser.PostfixToTree(output)
+	tree, err := GlobalFilterParser.PostfixToTree(ctx, output)
 	if err != nil {
 		t.Error(err)
 		return
@@ -1779,19 +1802,20 @@ func TestFilterSubstringNestedFunction(t *testing.T) {
 	}
 }
 func TestFilterGeoFunctions(t *testing.T) {
+	ctx := context.Background()
 	// Previously, the parser was incorrectly interpreting the 'geo.xxx' functions as the 'ge' operator.
 	input := "geo.distance(CurrentPosition,TargetPosition)"
-	tokens, err := GlobalExpressionTokenizer.Tokenize(input)
+	tokens, err := GlobalExpressionTokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	output, err := GlobalFilterParser.InfixToPostfix(tokens)
+	output, err := GlobalFilterParser.InfixToPostfix(ctx, tokens)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	tree, err := GlobalFilterParser.PostfixToTree(output)
+	tree, err := GlobalFilterParser.PostfixToTree(ctx, output)
 	if err != nil {
 		t.Error(err)
 		return
@@ -1809,18 +1833,19 @@ func TestFilterGeoFunctions(t *testing.T) {
 }
 
 func TestFilterLambdaAny(t *testing.T) {
+	ctx := context.Background()
 	input := "Tags/any(var:var/Key eq 'Site')"
-	tokens, err := GlobalExpressionTokenizer.Tokenize(input)
+	tokens, err := GlobalExpressionTokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	output, err := GlobalFilterParser.InfixToPostfix(tokens)
+	output, err := GlobalFilterParser.InfixToPostfix(ctx, tokens)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	tree, err := GlobalFilterParser.PostfixToTree(output)
+	tree, err := GlobalFilterParser.PostfixToTree(ctx, output)
 	if err != nil {
 		t.Error(err)
 		return
@@ -1845,14 +1870,15 @@ func TestFilterLambdaAny(t *testing.T) {
 }
 
 func TestFilterLambdaAnyNot(t *testing.T) {
+	ctx := context.Background()
 	input := "Price/any(t:not (12345 eq t ))"
 
-	tokens, err := GlobalExpressionTokenizer.Tokenize(input)
+	tokens, err := GlobalExpressionTokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	output, err := GlobalFilterParser.InfixToPostfix(tokens)
+	output, err := GlobalFilterParser.InfixToPostfix(ctx, tokens)
 	if err != nil {
 		t.Error(err)
 		return
@@ -1874,7 +1900,7 @@ func TestFilterLambdaAnyNot(t *testing.T) {
 			t.Error(err)
 		}
 	}
-	tree, err := GlobalFilterParser.PostfixToTree(output)
+	tree, err := GlobalFilterParser.PostfixToTree(ctx, output)
 	if err != nil {
 		t.Error(err)
 		return
@@ -1897,18 +1923,19 @@ func TestFilterLambdaAnyNot(t *testing.T) {
 }
 
 func TestFilterLambdaAnyAnd(t *testing.T) {
+	ctx := context.Background()
 	input := "Tags/any(var:var/Key eq 'Site' and var/Value eq 'London')"
-	tokens, err := GlobalExpressionTokenizer.Tokenize(input)
+	tokens, err := GlobalExpressionTokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	output, err := GlobalFilterParser.InfixToPostfix(tokens)
+	output, err := GlobalFilterParser.InfixToPostfix(ctx, tokens)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	tree, err := GlobalFilterParser.PostfixToTree(output)
+	tree, err := GlobalFilterParser.PostfixToTree(ctx, output)
 	if err != nil {
 		t.Error(err)
 		return
@@ -1974,18 +2001,19 @@ func TestFilterLambdaNestedAny(t *testing.T) {
 
 // TestLambdaAnyNested validates the any() lambda function with multiple nested properties.
 func TestFilterLambdaAnyNestedProperties(t *testing.T) {
+	ctx := context.Background()
 	input := "Config/any(var:var/Config/Priority eq 123)"
-	tokens, err := GlobalExpressionTokenizer.Tokenize(input)
+	tokens, err := GlobalExpressionTokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	output, err := GlobalFilterParser.InfixToPostfix(tokens)
+	output, err := GlobalFilterParser.InfixToPostfix(ctx, tokens)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	tree, err := GlobalFilterParser.PostfixToTree(output)
+	tree, err := GlobalFilterParser.PostfixToTree(ctx, output)
 	if err != nil {
 		t.Error(err)
 		return
@@ -2012,19 +2040,20 @@ func TestFilterLambdaAnyNestedProperties(t *testing.T) {
 }
 
 func TestFilterLambda2(t *testing.T) {
+	ctx := context.Background()
 	input := "Tags/any(var:var/Key eq 'Site' and var/Value eq 'London' or Price gt 1.0)"
-	tokens, err := GlobalExpressionTokenizer.Tokenize(input)
+	tokens, err := GlobalExpressionTokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	output, err := GlobalFilterParser.InfixToPostfix(tokens)
+	output, err := GlobalFilterParser.InfixToPostfix(ctx, tokens)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	tree, err := GlobalFilterParser.PostfixToTree(output)
+	tree, err := GlobalFilterParser.PostfixToTree(ctx, output)
 	if err != nil {
 		t.Error(err)
 		return
@@ -2058,19 +2087,20 @@ func TestFilterLambda2(t *testing.T) {
 }
 
 func TestFilterLambda3(t *testing.T) {
+	ctx := context.Background()
 	input := "Tags/any(var:var/Key eq 'Site' and var/Value eq 'London' or Price gt 1.0 or contains(var/Value, 'Smith'))"
-	tokens, err := GlobalExpressionTokenizer.Tokenize(input)
+	tokens, err := GlobalExpressionTokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	output, err := GlobalFilterParser.InfixToPostfix(tokens)
+	output, err := GlobalFilterParser.InfixToPostfix(ctx, tokens)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 
-	tree, err := GlobalFilterParser.PostfixToTree(output)
+	tree, err := GlobalFilterParser.PostfixToTree(ctx, output)
 	if err != nil {
 		t.Error(err)
 		return
@@ -2110,7 +2140,7 @@ func TestFilterLambda3(t *testing.T) {
 }
 
 func TestExpressionTokenizerExists(t *testing.T) {
-
+	ctx := context.Background()
 	tokenizer := NewExpressionTokenizer()
 	input := "exists(Name,false)"
 	expect := []*Token{
@@ -2121,7 +2151,7 @@ func TestExpressionTokenizerExists(t *testing.T) {
 		{Value: "false", Type: ExpressionTokenBoolean},
 		{Value: ")", Type: ExpressionTokenCloseParen},
 	}
-	output, err := tokenizer.Tokenize(input)
+	output, err := tokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 	}

--- a/inlinecount_parser.go
+++ b/inlinecount_parser.go
@@ -1,11 +1,13 @@
 package godata
 
+import "context"
+
 const (
 	ALLPAGES = "allpages"
 	NONE     = "none"
 )
 
-func ParseInlineCountString(inlinecount string) (*GoDataInlineCountQuery, error) {
+func ParseInlineCountString(ctx context.Context, inlinecount string) (*GoDataInlineCountQuery, error) {
 	result := GoDataInlineCountQuery(inlinecount)
 	if inlinecount == ALLPAGES {
 		return &result, nil

--- a/orderby_parser.go
+++ b/orderby_parser.go
@@ -17,14 +17,14 @@ type OrderByItem struct {
 }
 
 func ParseOrderByString(ctx context.Context, orderby string) (*GoDataOrderByQuery, error) {
-	return GlobalExpressionParser.ParseOrderByString(orderby)
+	return GlobalExpressionParser.ParseOrderByString(ctx, orderby)
 }
 
 // The value of the $orderby System Query option contains a comma-separated
 // list of expressions whose primitive result values are used to sort the items.
 // The service MUST order by the specified property in ascending order.
 // 4.01 services MUST support case-insensitive values for asc and desc.
-func (p *ExpressionParser) ParseOrderByString(orderby string) (*GoDataOrderByQuery, error) {
+func (p *ExpressionParser) ParseOrderByString(ctx context.Context, orderby string) (*GoDataOrderByQuery, error) {
 	items := strings.Split(orderby, ",")
 
 	result := make([]*OrderByItem, 0)
@@ -45,7 +45,7 @@ func (p *ExpressionParser) ParseOrderByString(orderby string) (*GoDataOrderByQue
 			v = strings.TrimSpace(v)
 		}
 
-		if tree, err := p.ParseExpressionString(v); err != nil {
+		if tree, err := p.ParseExpressionString(ctx, v); err != nil {
 			switch e := err.(type) {
 			case *GoDataError:
 				return nil, &GoDataError{

--- a/orderby_parser.go
+++ b/orderby_parser.go
@@ -1,6 +1,7 @@
 package godata
 
 import (
+	"context"
 	"strings"
 )
 
@@ -15,7 +16,7 @@ type OrderByItem struct {
 	Order string            // Ascending or descending order.
 }
 
-func ParseOrderByString(orderby string) (*GoDataOrderByQuery, error) {
+func ParseOrderByString(ctx context.Context, orderby string) (*GoDataOrderByQuery, error) {
 	return GlobalExpressionParser.ParseOrderByString(orderby)
 }
 

--- a/parser.go
+++ b/parser.go
@@ -331,6 +331,11 @@ func (p *Parser) InfixToPostfix(ctx context.Context, tokens []*Token) (*tokenQue
 			}
 		}
 	}
+	cfg, hasComplianceConfig := ctx.Value(odataCompliance).(OdataComplianceConfig)
+	if !hasComplianceConfig {
+		// Strict ODATA compliance by default.
+		cfg = ComplianceStrict
+	}
 	for len(tokens) > 0 {
 		token := tokens[0]
 		tokens = tokens[1:]
@@ -379,7 +384,9 @@ func (p *Parser) InfixToPostfix(ctx context.Context, tokens []*Token) (*tokenQue
 		case token.Value == TokenCloseParen:
 			previousTokenIsLiteral = false
 			if previousToken != nil && previousToken.Value == TokenComma {
-				return nil, fmt.Errorf("invalid token sequence: %s %s", previousToken.Value, token.Value)
+				if cfg&ComplianceIgnoreInvalidComma == 0 {
+					return nil, fmt.Errorf("invalid token sequence: %s %s", previousToken.Value, token.Value)
+				}
 			}
 			// if we find a close paren, pop things off the stack
 			for !stack.Empty() {

--- a/parser.go
+++ b/parser.go
@@ -1,6 +1,7 @@
 package godata
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"regexp"
@@ -106,7 +107,7 @@ func (t *Tokenizer) Ignore(pattern string, token TokenType) {
 
 // TokenizeBytes takes the input byte array and returns an array of tokens.
 // Return an empty array if there are no tokens.
-func (t *Tokenizer) TokenizeBytes(target []byte) ([]*Token, error) {
+func (t *Tokenizer) TokenizeBytes(ctx context.Context, target []byte) ([]*Token, error) {
 	result := make([]*Token, 0)
 	match := true // false when no match is found
 	for len(target) > 0 && match {
@@ -185,8 +186,8 @@ func (t *Tokenizer) TokenizeBytes(target []byte) ([]*Token, error) {
 	return result, nil
 }
 
-func (t *Tokenizer) Tokenize(target string) ([]*Token, error) {
-	return t.TokenizeBytes([]byte(target))
+func (t *Tokenizer) Tokenize(ctx context.Context, target string) ([]*Token, error) {
+	return t.TokenizeBytes(ctx, []byte(target))
 }
 
 type TokenHandler func(token *Token, stack tokenStack) error
@@ -314,7 +315,7 @@ func (p *Parser) isOperator(token *Token) bool {
 // Postfix notation with wall notation:                 | a b c d f
 // Postfix notation with count notation:                a b c d 4 f
 //
-func (p *Parser) InfixToPostfix(tokens []*Token) (*tokenQueue, error) {
+func (p *Parser) InfixToPostfix(ctx context.Context, tokens []*Token) (*tokenQueue, error) {
 	queue := tokenQueue{} // output queue in postfix
 	stack := tokenStack{} // Operator stack
 
@@ -531,7 +532,7 @@ func (p *Parser) InfixToPostfix(tokens []*Token) (*tokenQueue, error) {
 }
 
 // PostfixToTree converts a Postfix token queue to a parse tree
-func (p *Parser) PostfixToTree(queue *tokenQueue) (*ParseNode, error) {
+func (p *Parser) PostfixToTree(ctx context.Context, queue *tokenQueue) (*ParseNode, error) {
 	stack := &nodeStack{}
 	currNode := &ParseNode{}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -1,11 +1,13 @@
 package godata
 
 import (
+	"context"
 	"strconv"
 	"testing"
 )
 
 func TestPEMDAS(t *testing.T) {
+	ctx := context.Background()
 	parser := EmptyParser()
 	parser.DefineFunction("sin", []int{1})
 	parser.DefineFunction("max", []int{2})
@@ -38,7 +40,7 @@ func TestPEMDAS(t *testing.T) {
 	expected := []string{"3", "4", "2", "*", "1", "5", "-", "2", "3", "^", "^",
 		"/", "+"}
 
-	result, err := parser.InfixToPostfix(tokens)
+	result, err := parser.InfixToPostfix(ctx, tokens)
 
 	if err != nil {
 		t.Error(err)
@@ -60,6 +62,7 @@ func TestPEMDAS(t *testing.T) {
 }
 
 func BenchmarkPEMDAS(b *testing.B) {
+	ctx := context.Background()
 	parser := EmptyParser()
 	parser.DefineFunction("sin", []int{1})
 	parser.DefineFunction("max", []int{2})
@@ -89,13 +92,14 @@ func BenchmarkPEMDAS(b *testing.B) {
 	}
 
 	for i := 0; i < b.N; i++ {
-		if _, err := parser.InfixToPostfix(tokens); err != nil {
+		if _, err := parser.InfixToPostfix(ctx, tokens); err != nil {
 			b.Fatalf("Failed to transform tokens from infix to postfix: %v", err)
 		}
 	}
 }
 
 func TestBoolean(t *testing.T) {
+	ctx := context.Background()
 	parser := EmptyParser()
 	parser.DefineOperator("NOT", 1, OpAssociationNone, 3)
 	parser.DefineOperator("AND", 2, OpAssociationLeft, 2)
@@ -117,7 +121,7 @@ func TestBoolean(t *testing.T) {
 
 	// A B NOT OR C AND B OR
 	expected := []string{"A", "B", "NOT", "OR", "C", "AND", "B", "OR"}
-	result, err := parser.InfixToPostfix(tokens)
+	result, err := parser.InfixToPostfix(ctx, tokens)
 
 	if err != nil {
 		t.Error(err)
@@ -139,6 +143,7 @@ func TestBoolean(t *testing.T) {
 }
 
 func TestFunc(t *testing.T) {
+	ctx := context.Background()
 	parser := EmptyParser()
 	parser.DefineFunction("sin", []int{1})
 	parser.DefineFunction("max", []int{2})
@@ -188,7 +193,7 @@ func TestFunc(t *testing.T) {
 		"volume", "2",
 		"/", "+",
 		"2" /* arg count */, "list" /* list expression */, "max"}
-	result, err := parser.InfixToPostfix(tokens)
+	result, err := parser.InfixToPostfix(ctx, tokens)
 
 	if err != nil {
 		t.Error(err)
@@ -209,6 +214,7 @@ func TestFunc(t *testing.T) {
 }
 
 func TestTree(t *testing.T) {
+	ctx := context.Background()
 	parser := EmptyParser()
 	parser.DefineFunction("sin", []int{1})
 	parser.DefineFunction("max", []int{2})
@@ -236,12 +242,12 @@ func TestTree(t *testing.T) {
 	}
 
 	// 2 3 max 3 / 3.1415 * sin
-	result, err := parser.InfixToPostfix(tokens)
+	result, err := parser.InfixToPostfix(ctx, tokens)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	root, err := parser.PostfixToTree(result)
+	root, err := parser.PostfixToTree(ctx, result)
 	if err != nil {
 		t.Fatalf("Error parsing query: %v", err)
 	}
@@ -272,6 +278,7 @@ func TestTree(t *testing.T) {
 }
 
 func BenchmarkBuildTree(b *testing.B) {
+	ctx := context.Background()
 	parser := EmptyParser()
 	parser.DefineFunction("sin", []int{1})
 	parser.DefineFunction("max", []int{2})
@@ -300,8 +307,8 @@ func BenchmarkBuildTree(b *testing.B) {
 
 	// 2 3 max 3 / 3.1415 * sin
 	for i := 0; i < b.N; i++ {
-		result, _ := parser.InfixToPostfix(tokens)
-		if _, err := parser.PostfixToTree(result); err != nil {
+		result, _ := parser.InfixToPostfix(ctx, tokens)
+		if _, err := parser.PostfixToTree(ctx, result); err != nil {
 			b.Fatalf("Failed to transform tokens: %v", err)
 		}
 	}

--- a/request_model.go
+++ b/request_model.go
@@ -2,8 +2,10 @@ package godata
 
 type GoDataIdentifier map[string]string
 
+type RequestKind int
+
 const (
-	RequestKindUnknown int = iota
+	RequestKindUnknown RequestKind = iota
 	RequestKindMetadata
 	RequestKindService
 	RequestKindEntity
@@ -35,7 +37,7 @@ type GoDataRequest struct {
 	FirstSegment *GoDataSegment
 	LastSegment  *GoDataSegment
 	Query        *GoDataQuery
-	RequestKind  int
+	RequestKind  RequestKind
 }
 
 // Represents a segment (slash-separated) part of the URI path. Each segment

--- a/search_parser.go
+++ b/search_parser.go
@@ -1,5 +1,7 @@
 package godata
 
+import "context"
+
 type SearchTokenType int
 
 func (s SearchTokenType) Value() int {
@@ -19,7 +21,7 @@ var GlobalSearchParser = SearchParser()
 
 // Convert an input string from the $filter part of the URL into a parse
 // tree that can be used by providers to create a response.
-func ParseSearchString(filter string) (*GoDataSearchQuery, error) {
+func ParseSearchString(ctx context.Context, filter string) (*GoDataSearchQuery, error) {
 	tokens, err := GlobalSearchTokenizer.Tokenize(filter)
 	if err != nil {
 		return nil, err

--- a/search_parser.go
+++ b/search_parser.go
@@ -22,15 +22,15 @@ var GlobalSearchParser = SearchParser()
 // Convert an input string from the $filter part of the URL into a parse
 // tree that can be used by providers to create a response.
 func ParseSearchString(ctx context.Context, filter string) (*GoDataSearchQuery, error) {
-	tokens, err := GlobalSearchTokenizer.Tokenize(filter)
+	tokens, err := GlobalSearchTokenizer.Tokenize(ctx, filter)
 	if err != nil {
 		return nil, err
 	}
-	postfix, err := GlobalSearchParser.InfixToPostfix(tokens)
+	postfix, err := GlobalSearchParser.InfixToPostfix(ctx, tokens)
 	if err != nil {
 		return nil, err
 	}
-	tree, err := GlobalSearchParser.PostfixToTree(postfix)
+	tree, err := GlobalSearchParser.PostfixToTree(ctx, postfix)
 	if err != nil {
 		return nil, err
 	}

--- a/search_parser_test.go
+++ b/search_parser_test.go
@@ -1,10 +1,12 @@
 package godata
 
 import (
+	"context"
 	"testing"
 )
 
 func TestSearchQuery(t *testing.T) {
+	ctx := context.Background()
 	tokenizer := SearchTokenizer()
 	input := "mountain OR (\"red bikes\" AND avocados)"
 
@@ -17,7 +19,7 @@ func TestSearchQuery(t *testing.T) {
 		{Value: "avocados", Type: SearchTokenLiteral},
 		{Value: ")", Type: SearchTokenCloseParen},
 	}
-	output, err := tokenizer.Tokenize(input)
+	output, err := tokenizer.Tokenize(ctx, input)
 	if err != nil {
 		t.Error(err)
 	}

--- a/select_parser.go
+++ b/select_parser.go
@@ -1,6 +1,7 @@
 package godata
 
 import (
+	"context"
 	"errors"
 	"strings"
 )
@@ -9,7 +10,7 @@ type SelectItem struct {
 	Segments []*Token
 }
 
-func ParseSelectString(sel string) (*GoDataSelectQuery, error) {
+func ParseSelectString(ctx context.Context, sel string) (*GoDataSelectQuery, error) {
 	items := strings.Split(sel, ",")
 
 	result := []*SelectItem{}

--- a/service.go
+++ b/service.go
@@ -1,6 +1,7 @@
 package godata
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"strings"
@@ -142,8 +143,8 @@ func BuildService(provider GoDataProvider, serviceUrl string) (*GoDataService, e
 // The default handler for parsing requests as GoDataRequests, passing them
 // to a GoData provider, and then building a response.
 func (service *GoDataService) GoDataHTTPHandler(w http.ResponseWriter, r *http.Request) {
-
-	request, err := ParseRequest(r.URL.Path, r.URL.Query(), false)
+	ctx := context.Background()
+	request, err := ParseRequest(ctx, r.URL.Path, r.URL.Query(), false)
 
 	if err != nil {
 		panic(err) // TODO: return proper error
@@ -151,7 +152,7 @@ func (service *GoDataService) GoDataHTTPHandler(w http.ResponseWriter, r *http.R
 
 	// Semanticize all tokens in the request, connecting them with their
 	// corresponding types in the service
-	err = SemanticizeRequest(request, service)
+	err = request.SemanticizeRequest(service)
 
 	if err != nil {
 		panic(err) // TODO: return proper error

--- a/service.go
+++ b/service.go
@@ -144,7 +144,7 @@ func BuildService(provider GoDataProvider, serviceUrl string) (*GoDataService, e
 // to a GoData provider, and then building a response.
 func (service *GoDataService) GoDataHTTPHandler(w http.ResponseWriter, r *http.Request) {
 	ctx := context.Background()
-	request, err := ParseRequest(ctx, r.URL.Path, r.URL.Query(), false)
+	request, err := ParseRequest(ctx, r.URL.Path, r.URL.Query())
 
 	if err != nil {
 		panic(err) // TODO: return proper error

--- a/service_test.go
+++ b/service_test.go
@@ -1,6 +1,7 @@
 package godata
 
 import (
+	"context"
 	"net/url"
 	"testing"
 )
@@ -111,8 +112,8 @@ func TestSemanticizeRequest(t *testing.T) {
 		t.Error(err)
 		return
 	}
-
-	req, err := ParseRequest(url.Path, url.Query(), false)
+	ctx := context.Background()
+	req, err := ParseRequest(ctx, url.Path, url.Query(), false)
 
 	if err != nil {
 		t.Error(err)
@@ -126,7 +127,7 @@ func TestSemanticizeRequest(t *testing.T) {
 		return
 	}
 
-	err = SemanticizeRequest(req, service)
+	err = req.SemanticizeRequest(service)
 
 	if err != nil {
 		t.Error(err)
@@ -179,8 +180,8 @@ func TestSemanticizeRequestWildcard(t *testing.T) {
 		t.Error(err)
 		return
 	}
-
-	req, err := ParseRequest(url.Path, url.Query(), false)
+	ctx := context.Background()
+	req, err := ParseRequest(ctx, url.Path, url.Query(), false)
 
 	if err != nil {
 		t.Error(err)
@@ -194,7 +195,7 @@ func TestSemanticizeRequestWildcard(t *testing.T) {
 		return
 	}
 
-	err = SemanticizeRequest(req, service)
+	err = req.SemanticizeRequest(service)
 
 	if err != nil {
 		t.Errorf("Failed to semanticize request. Error: %v", err)
@@ -260,10 +261,9 @@ func BenchmarkTypicalParseSemanticizeRequest(b *testing.B) {
 		b.Error(err)
 		return
 	}
-
+	ctx := context.Background()
 	for n := 0; n < b.N; n++ {
-
-		req, err := ParseRequest(url.Path, url.Query(), false)
+		req, err := ParseRequest(ctx, url.Path, url.Query(), false)
 
 		if err != nil {
 			b.Error(err)
@@ -277,7 +277,7 @@ func BenchmarkTypicalParseSemanticizeRequest(b *testing.B) {
 			return
 		}
 
-		err = SemanticizeRequest(req, service)
+		err = req.SemanticizeRequest(service)
 
 		if err != nil {
 			b.Error(err)
@@ -297,10 +297,9 @@ func BenchmarkWildcardParseSemanticizeRequest(b *testing.B) {
 		b.Error(err)
 		return
 	}
-
+	ctx := context.Background()
 	for n := 0; n < b.N; n++ {
-
-		req, err := ParseRequest(url.Path, url.Query(), false)
+		req, err := ParseRequest(ctx, url.Path, url.Query(), false)
 
 		if err != nil {
 			b.Error(err)
@@ -314,7 +313,7 @@ func BenchmarkWildcardParseSemanticizeRequest(b *testing.B) {
 			return
 		}
 
-		err = SemanticizeRequest(req, service)
+		err = req.SemanticizeRequest(service)
 
 		if err != nil {
 			b.Error(err)

--- a/service_test.go
+++ b/service_test.go
@@ -113,7 +113,7 @@ func TestSemanticizeRequest(t *testing.T) {
 		return
 	}
 	ctx := context.Background()
-	req, err := ParseRequest(ctx, url.Path, url.Query(), false)
+	req, err := ParseRequest(ctx, url.Path, url.Query())
 
 	if err != nil {
 		t.Error(err)
@@ -181,7 +181,7 @@ func TestSemanticizeRequestWildcard(t *testing.T) {
 		return
 	}
 	ctx := context.Background()
-	req, err := ParseRequest(ctx, url.Path, url.Query(), false)
+	req, err := ParseRequest(ctx, url.Path, url.Query())
 
 	if err != nil {
 		t.Error(err)
@@ -263,7 +263,7 @@ func BenchmarkTypicalParseSemanticizeRequest(b *testing.B) {
 	}
 	ctx := context.Background()
 	for n := 0; n < b.N; n++ {
-		req, err := ParseRequest(ctx, url.Path, url.Query(), false)
+		req, err := ParseRequest(ctx, url.Path, url.Query())
 
 		if err != nil {
 			b.Error(err)
@@ -299,7 +299,7 @@ func BenchmarkWildcardParseSemanticizeRequest(b *testing.B) {
 	}
 	ctx := context.Background()
 	for n := 0; n < b.N; n++ {
-		req, err := ParseRequest(ctx, url.Path, url.Query(), false)
+		req, err := ParseRequest(ctx, url.Path, url.Query())
 
 		if err != nil {
 			b.Error(err)

--- a/topskip_parser.go
+++ b/topskip_parser.go
@@ -1,16 +1,17 @@
 package godata
 
 import (
+	"context"
 	"strconv"
 )
 
-func ParseTopString(top string) (*GoDataTopQuery, error) {
+func ParseTopString(ctx context.Context, top string) (*GoDataTopQuery, error) {
 	i, err := strconv.Atoi(top)
 	result := GoDataTopQuery(i)
 	return &result, err
 }
 
-func ParseSkipString(skip string) (*GoDataSkipQuery, error) {
+func ParseSkipString(ctx context.Context, skip string) (*GoDataSkipQuery, error) {
 	i, err := strconv.Atoi(skip)
 	result := GoDataSkipQuery(i)
 	return &result, err

--- a/url_parser.go
+++ b/url_parser.go
@@ -1,100 +1,105 @@
 package godata
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
 )
 
+func NewGoDataRequest() *GoDataRequest {
+	return &GoDataRequest{}
+}
+
 // Parse a request from the HTTP server and format it into a GoDaataRequest type
 // to be passed to a provider to produce a result.
-func ParseRequest(path string, query url.Values, lenient bool) (*GoDataRequest, error) {
-
-	firstSegment, lastSegment, err := ParseUrlPath(path)
-	if err != nil {
-		return nil, err
-	}
-	parsedQuery, err := ParseUrlQuery(query, lenient)
-	if err != nil {
-		return nil, err
+func ParseRequest(ctx context.Context, path string, query url.Values, lenient bool) (*GoDataRequest, error) {
+	r := &GoDataRequest{
+		RequestKind: RequestKindUnknown,
 	}
 
-	return &GoDataRequest{firstSegment, lastSegment, parsedQuery, RequestKindUnknown}, nil
+	if err := r.ParseUrlPath(path); err != nil {
+		return nil, err
+	}
+	if err := r.ParseUrlQuery(ctx, query, lenient); err != nil {
+		return nil, err
+	}
+	return r, nil
 }
 
 // Compare a request to a given service, and validate the semantics and update
 // the request with semantics included
-func SemanticizeRequest(req *GoDataRequest, service *GoDataService) error {
+func (r *GoDataRequest) SemanticizeRequest(service *GoDataService) error {
 
 	// if request kind is a resource
-	for segment := req.FirstSegment; segment != nil; segment = segment.Next {
+	for segment := r.FirstSegment; segment != nil; segment = segment.Next {
 		err := SemanticizePathSegment(segment, service)
 		if err != nil {
 			return err
 		}
 	}
 
-	switch req.LastSegment.SemanticReference.(type) {
+	switch r.LastSegment.SemanticReference.(type) {
 	case *GoDataEntitySet:
-		entitySet := req.LastSegment.SemanticReference.(*GoDataEntitySet)
+		entitySet := r.LastSegment.SemanticReference.(*GoDataEntitySet)
 		entityType, err := service.LookupEntityType(entitySet.EntityType)
 		if err != nil {
 			return err
 		}
-		err = SemanticizeFilterQuery(req.Query.Filter, service, entityType)
+		err = SemanticizeFilterQuery(r.Query.Filter, service, entityType)
 		if err != nil {
 			return err
 		}
-		err = SemanticizeExpandQuery(req.Query.Expand, service, entityType)
+		err = SemanticizeExpandQuery(r.Query.Expand, service, entityType)
 		if err != nil {
 			return err
 		}
-		err = SemanticizeSelectQuery(req.Query.Select, service, entityType)
+		err = SemanticizeSelectQuery(r.Query.Select, service, entityType)
 		if err != nil {
 			return err
 		}
-		err = SemanticizeOrderByQuery(req.Query.OrderBy, service, entityType)
+		err = SemanticizeOrderByQuery(r.Query.OrderBy, service, entityType)
 		if err != nil {
 			return err
 		}
 		// TODO: disallow invalid query params
 	case *GoDataEntityType:
-		entityType := req.LastSegment.SemanticReference.(*GoDataEntityType)
-		if err := SemanticizeExpandQuery(req.Query.Expand, service, entityType); err != nil {
+		entityType := r.LastSegment.SemanticReference.(*GoDataEntityType)
+		if err := SemanticizeExpandQuery(r.Query.Expand, service, entityType); err != nil {
 			return err
 		}
-		if err := SemanticizeSelectQuery(req.Query.Select, service, entityType); err != nil {
+		if err := SemanticizeSelectQuery(r.Query.Select, service, entityType); err != nil {
 			return err
 		}
 	}
 
-	if req.LastSegment.SemanticType == SemanticTypeMetadata {
-		req.RequestKind = RequestKindMetadata
-	} else if req.LastSegment.SemanticType == SemanticTypeRef {
-		req.RequestKind = RequestKindRef
-	} else if req.LastSegment.SemanticType == SemanticTypeEntitySet {
-		if req.LastSegment.Identifier == nil {
-			req.RequestKind = RequestKindCollection
+	if r.LastSegment.SemanticType == SemanticTypeMetadata {
+		r.RequestKind = RequestKindMetadata
+	} else if r.LastSegment.SemanticType == SemanticTypeRef {
+		r.RequestKind = RequestKindRef
+	} else if r.LastSegment.SemanticType == SemanticTypeEntitySet {
+		if r.LastSegment.Identifier == nil {
+			r.RequestKind = RequestKindCollection
 		} else {
-			req.RequestKind = RequestKindEntity
+			r.RequestKind = RequestKindEntity
 		}
-	} else if req.LastSegment.SemanticType == SemanticTypeCount {
-		req.RequestKind = RequestKindCount
-	} else if req.FirstSegment == nil && req.LastSegment == nil {
-		req.RequestKind = RequestKindService
+	} else if r.LastSegment.SemanticType == SemanticTypeCount {
+		r.RequestKind = RequestKindCount
+	} else if r.FirstSegment == nil && r.LastSegment == nil {
+		r.RequestKind = RequestKindService
 	}
 
 	return nil
 }
 
-func ParseUrlPath(path string) (*GoDataSegment, *GoDataSegment, error) {
+func (r *GoDataRequest) ParseUrlPath(path string) error {
 	parts := strings.Split(path, "/")
-	firstSegment := &GoDataSegment{
+	r.FirstSegment = &GoDataSegment{
 		RawValue:   parts[0],
 		Name:       ParseName(parts[0]),
 		Identifier: ParseIdentifiers(parts[0]),
 	}
-	currSegment := firstSegment
+	currSegment := r.FirstSegment
 	for _, v := range parts[1:] {
 		temp := &GoDataSegment{
 			RawValue:   v,
@@ -105,9 +110,9 @@ func ParseUrlPath(path string) (*GoDataSegment, *GoDataSegment, error) {
 		currSegment.Next = temp
 		currSegment = temp
 	}
-	lastSegment := currSegment
+	r.LastSegment = currSegment
 
-	return firstSegment, lastSegment, nil
+	return nil
 }
 
 func SemanticizePathSegment(segment *GoDataSegment, service *GoDataService) error {
@@ -225,16 +230,20 @@ var supportedOdataKeywords = map[string]bool{
 	"tags":         true,
 }
 
-func ParseUrlQuery(query url.Values, lenient bool) (*GoDataQuery, error) {
+// If lenient is true, the following logic is applied. If lenient is false, return an error:
+// - Allow duplicate ODATA keywords in the URL query.
+// - Ignore unknown ODATA keywords in the URL query.
+// - Allow extraneous comma as the last character in a list of function arguments.
+func (r *GoDataRequest) ParseUrlQuery(ctx context.Context, query url.Values, lenient bool) error {
 	if !lenient {
 		// Validate each query parameter is a valid ODATA keyword.
 		for key, val := range query {
 			if _, ok := supportedOdataKeywords[key]; !ok {
-				return nil, BadRequestError(fmt.Sprintf("Query parameter '%s' is not supported", key)).
+				return BadRequestError(fmt.Sprintf("Query parameter '%s' is not supported", key)).
 					SetCause(&UnsupportedQueryParameterError{key})
 			}
 			if len(val) > 1 {
-				return nil, BadRequestError(fmt.Sprintf("Query parameter '%s' cannot be specified more than once", key)).
+				return BadRequestError(fmt.Sprintf("Query parameter '%s' cannot be specified more than once", key)).
 					SetCause(&DuplicateQueryParameterError{key})
 			}
 		}
@@ -256,85 +265,85 @@ func ParseUrlQuery(query url.Values, lenient bool) (*GoDataQuery, error) {
 
 	var err error = nil
 	if filter != "" {
-		result.Filter, err = ParseFilterString(filter)
+		result.Filter, err = ParseFilterString(ctx, filter)
 	}
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if at != "" {
-		result.At, err = ParseFilterString(at)
+		result.At, err = ParseFilterString(ctx, at)
 	}
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if at != "" {
-		result.At, err = ParseFilterString(at)
+		result.At, err = ParseFilterString(ctx, at)
 	}
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if apply != "" {
-		result.Apply, err = ParseApplyString(apply)
+		result.Apply, err = ParseApplyString(ctx, apply)
 	}
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if expand != "" {
-		result.Expand, err = ParseExpandString(expand)
+		result.Expand, err = ParseExpandString(ctx, expand)
 	}
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if sel != "" {
-		result.Select, err = ParseSelectString(sel)
+		result.Select, err = ParseSelectString(ctx, sel)
 	}
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if orderby != "" {
-		result.OrderBy, err = ParseOrderByString(orderby)
+		result.OrderBy, err = ParseOrderByString(ctx, orderby)
 	}
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if top != "" {
-		result.Top, err = ParseTopString(top)
+		result.Top, err = ParseTopString(ctx, top)
 	}
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if skip != "" {
-		result.Skip, err = ParseSkipString(skip)
+		result.Skip, err = ParseSkipString(ctx, skip)
 	}
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if count != "" {
-		result.Count, err = ParseCountString(count)
+		result.Count, err = ParseCountString(ctx, count)
 	}
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if inlinecount != "" {
-		result.InlineCount, err = ParseInlineCountString(inlinecount)
+		result.InlineCount, err = ParseInlineCountString(ctx, inlinecount)
 	}
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if search != "" {
-		result.Search, err = ParseSearchString(search)
+		result.Search, err = ParseSearchString(ctx, search)
 	}
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if format != "" {
 		err = NotImplementedError("Format is not supported")
 	}
 	if err != nil {
-		return nil, err
+		return err
 	}
-
-	return result, err
+	r.Query = result
+	return err
 }
 
 func ParseIdentifiers(segment string) *GoDataIdentifier {

--- a/url_parser.go
+++ b/url_parser.go
@@ -230,11 +230,11 @@ type OdataComplianceConfig int
 
 const (
 	ComplianceStrict OdataComplianceConfig = 0
-	// Ingore duplicate ODATA keywords in the URL query.
+	// Ignore duplicate ODATA keywords in the URL query.
 	ComplianceIgnoreDuplicateKeywords OdataComplianceConfig = 1 << iota
 	// Ignore unknown ODATA keywords in the URL query.
 	ComplianceIgnoreUnknownKeywords
-	// Ingore extraneous comma as the last character in a list of function arguments.
+	// Ignore extraneous comma as the last character in a list of function arguments.
 	ComplianceIgnoreInvalidComma
 	ComplianceIgnoreAll OdataComplianceConfig = ComplianceIgnoreDuplicateKeywords |
 		ComplianceIgnoreUnknownKeywords |

--- a/url_parser.go
+++ b/url_parser.go
@@ -13,7 +13,7 @@ func NewGoDataRequest() *GoDataRequest {
 
 // Parse a request from the HTTP server and format it into a GoDaataRequest type
 // to be passed to a provider to produce a result.
-func ParseRequest(ctx context.Context, path string, query url.Values, lenient bool) (*GoDataRequest, error) {
+func ParseRequest(ctx context.Context, path string, query url.Values) (*GoDataRequest, error) {
 	r := &GoDataRequest{
 		RequestKind: RequestKindUnknown,
 	}
@@ -21,7 +21,7 @@ func ParseRequest(ctx context.Context, path string, query url.Values, lenient bo
 	if err := r.ParseUrlPath(path); err != nil {
 		return nil, err
 	}
-	if err := r.ParseUrlQuery(ctx, query, lenient); err != nil {
+	if err := r.ParseUrlQuery(ctx, query); err != nil {
 		return nil, err
 	}
 	return r, nil
@@ -29,77 +29,77 @@ func ParseRequest(ctx context.Context, path string, query url.Values, lenient bo
 
 // Compare a request to a given service, and validate the semantics and update
 // the request with semantics included
-func (r *GoDataRequest) SemanticizeRequest(service *GoDataService) error {
+func (req *GoDataRequest) SemanticizeRequest(service *GoDataService) error {
 
 	// if request kind is a resource
-	for segment := r.FirstSegment; segment != nil; segment = segment.Next {
+	for segment := req.FirstSegment; segment != nil; segment = segment.Next {
 		err := SemanticizePathSegment(segment, service)
 		if err != nil {
 			return err
 		}
 	}
 
-	switch r.LastSegment.SemanticReference.(type) {
+	switch req.LastSegment.SemanticReference.(type) {
 	case *GoDataEntitySet:
-		entitySet := r.LastSegment.SemanticReference.(*GoDataEntitySet)
+		entitySet := req.LastSegment.SemanticReference.(*GoDataEntitySet)
 		entityType, err := service.LookupEntityType(entitySet.EntityType)
 		if err != nil {
 			return err
 		}
-		err = SemanticizeFilterQuery(r.Query.Filter, service, entityType)
+		err = SemanticizeFilterQuery(req.Query.Filter, service, entityType)
 		if err != nil {
 			return err
 		}
-		err = SemanticizeExpandQuery(r.Query.Expand, service, entityType)
+		err = SemanticizeExpandQuery(req.Query.Expand, service, entityType)
 		if err != nil {
 			return err
 		}
-		err = SemanticizeSelectQuery(r.Query.Select, service, entityType)
+		err = SemanticizeSelectQuery(req.Query.Select, service, entityType)
 		if err != nil {
 			return err
 		}
-		err = SemanticizeOrderByQuery(r.Query.OrderBy, service, entityType)
+		err = SemanticizeOrderByQuery(req.Query.OrderBy, service, entityType)
 		if err != nil {
 			return err
 		}
 		// TODO: disallow invalid query params
 	case *GoDataEntityType:
-		entityType := r.LastSegment.SemanticReference.(*GoDataEntityType)
-		if err := SemanticizeExpandQuery(r.Query.Expand, service, entityType); err != nil {
+		entityType := req.LastSegment.SemanticReference.(*GoDataEntityType)
+		if err := SemanticizeExpandQuery(req.Query.Expand, service, entityType); err != nil {
 			return err
 		}
-		if err := SemanticizeSelectQuery(r.Query.Select, service, entityType); err != nil {
+		if err := SemanticizeSelectQuery(req.Query.Select, service, entityType); err != nil {
 			return err
 		}
 	}
 
-	if r.LastSegment.SemanticType == SemanticTypeMetadata {
-		r.RequestKind = RequestKindMetadata
-	} else if r.LastSegment.SemanticType == SemanticTypeRef {
-		r.RequestKind = RequestKindRef
-	} else if r.LastSegment.SemanticType == SemanticTypeEntitySet {
-		if r.LastSegment.Identifier == nil {
-			r.RequestKind = RequestKindCollection
+	if req.LastSegment.SemanticType == SemanticTypeMetadata {
+		req.RequestKind = RequestKindMetadata
+	} else if req.LastSegment.SemanticType == SemanticTypeRef {
+		req.RequestKind = RequestKindRef
+	} else if req.LastSegment.SemanticType == SemanticTypeEntitySet {
+		if req.LastSegment.Identifier == nil {
+			req.RequestKind = RequestKindCollection
 		} else {
-			r.RequestKind = RequestKindEntity
+			req.RequestKind = RequestKindEntity
 		}
-	} else if r.LastSegment.SemanticType == SemanticTypeCount {
-		r.RequestKind = RequestKindCount
-	} else if r.FirstSegment == nil && r.LastSegment == nil {
-		r.RequestKind = RequestKindService
+	} else if req.LastSegment.SemanticType == SemanticTypeCount {
+		req.RequestKind = RequestKindCount
+	} else if req.FirstSegment == nil && req.LastSegment == nil {
+		req.RequestKind = RequestKindService
 	}
 
 	return nil
 }
 
-func (r *GoDataRequest) ParseUrlPath(path string) error {
+func (req *GoDataRequest) ParseUrlPath(path string) error {
 	parts := strings.Split(path, "/")
-	r.FirstSegment = &GoDataSegment{
+	req.FirstSegment = &GoDataSegment{
 		RawValue:   parts[0],
 		Name:       ParseName(parts[0]),
 		Identifier: ParseIdentifiers(parts[0]),
 	}
-	currSegment := r.FirstSegment
+	currSegment := req.FirstSegment
 	for _, v := range parts[1:] {
 		temp := &GoDataSegment{
 			RawValue:   v,
@@ -110,7 +110,7 @@ func (r *GoDataRequest) ParseUrlPath(path string) error {
 		currSegment.Next = temp
 		currSegment = temp
 	}
-	r.LastSegment = currSegment
+	req.LastSegment = currSegment
 
 	return nil
 }
@@ -230,22 +230,50 @@ var supportedOdataKeywords = map[string]bool{
 	"tags":         true,
 }
 
-// If lenient is true, the following logic is applied. If lenient is false, return an error:
-// - Allow duplicate ODATA keywords in the URL query.
-// - Ignore unknown ODATA keywords in the URL query.
-// - Allow extraneous comma as the last character in a list of function arguments.
-func (r *GoDataRequest) ParseUrlQuery(ctx context.Context, query url.Values, lenient bool) error {
-	if !lenient {
-		// Validate each query parameter is a valid ODATA keyword.
-		for key, val := range query {
-			if _, ok := supportedOdataKeywords[key]; !ok {
-				return BadRequestError(fmt.Sprintf("Query parameter '%s' is not supported", key)).
-					SetCause(&UnsupportedQueryParameterError{key})
-			}
-			if len(val) > 1 {
-				return BadRequestError(fmt.Sprintf("Query parameter '%s' cannot be specified more than once", key)).
-					SetCause(&DuplicateQueryParameterError{key})
-			}
+type OdataComplianceConfig int
+
+const (
+	ComplianceStrict OdataComplianceConfig = 0
+	// Ingore duplicate ODATA keywords in the URL query.
+	ComplianceIgnoreDuplicateKeywords OdataComplianceConfig = 1 << iota
+	// Ignore unknown ODATA keywords in the URL query.
+	ComplianceIgnoreUnknownKeywords
+	// Ingore extraneous comma as the last character in a list of function arguments.
+	ComplianceIgnoreInvalidComma
+	ComplianceIgnoreAll OdataComplianceConfig = ComplianceIgnoreDuplicateKeywords |
+		ComplianceIgnoreUnknownKeywords |
+		ComplianceIgnoreInvalidComma
+)
+
+type parserConfigKey int
+
+const (
+	odataCompliance parserConfigKey = iota
+)
+
+// If the lenient mode is set, the 'failOnConfig' bits are used to determine the ODATA compliance.
+// This is mostly for historical reasons because the original parser had compliance issues.
+// If the lenient mode is not set, the parser returns an error.
+func WithOdataComplianceConfig(ctx context.Context, cfg OdataComplianceConfig) context.Context {
+	return context.WithValue(ctx, odataCompliance, cfg)
+}
+
+// ParseUrlQuery parses the URL query, applying optional logic specified in the context.
+func (req *GoDataRequest) ParseUrlQuery(ctx context.Context, query url.Values) error {
+	cfg, hasComplianceConfig := ctx.Value(odataCompliance).(OdataComplianceConfig)
+	if !hasComplianceConfig {
+		// Strict ODATA compliance by default.
+		cfg = ComplianceStrict
+	}
+	// Validate each query parameter is a valid ODATA keyword.
+	for key, val := range query {
+		if _, ok := supportedOdataKeywords[key]; !ok && (cfg&ComplianceIgnoreUnknownKeywords == 0) {
+			return BadRequestError(fmt.Sprintf("Query parameter '%s' is not supported", key)).
+				SetCause(&UnsupportedQueryParameterError{key})
+		}
+		if (cfg&ComplianceIgnoreDuplicateKeywords == 0) && (len(val) > 1) {
+			return BadRequestError(fmt.Sprintf("Query parameter '%s' cannot be specified more than once", key)).
+				SetCause(&DuplicateQueryParameterError{key})
 		}
 	}
 	filter := query.Get("$filter")
@@ -342,7 +370,7 @@ func (r *GoDataRequest) ParseUrlQuery(ctx context.Context, query url.Values, len
 	if err != nil {
 		return err
 	}
-	r.Query = result
+	req.Query = result
 	return err
 }
 

--- a/url_parser.go
+++ b/url_parser.go
@@ -7,10 +7,6 @@ import (
 	"strings"
 )
 
-func NewGoDataRequest() *GoDataRequest {
-	return &GoDataRequest{}
-}
-
 // Parse a request from the HTTP server and format it into a GoDaataRequest type
 // to be passed to a provider to produce a result.
 func ParseRequest(ctx context.Context, path string, query url.Values) (*GoDataRequest, error) {

--- a/url_parser_test.go
+++ b/url_parser_test.go
@@ -1,6 +1,7 @@
 package godata
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -15,8 +16,8 @@ func TestUrlParser(t *testing.T) {
 		t.Error(err)
 		return
 	}
-
-	request, err := ParseRequest(parsedUrl.Path, parsedUrl.Query(), false)
+	ctx := context.Background()
+	request, err := ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false)
 
 	if err != nil {
 		t.Error(err)
@@ -44,7 +45,8 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(parsedUrl.Path, parsedUrl.Query(), false)
+	ctx := context.Background()
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false)
 	if err != nil {
 		t.Error(err)
 		return
@@ -56,7 +58,7 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(parsedUrl.Path, parsedUrl.Query(), false)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false)
 	if err != nil {
 		t.Error(err)
 		return
@@ -69,7 +71,7 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(parsedUrl.Path, parsedUrl.Query(), false)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false)
 	if err == nil {
 		t.Errorf("Parser should have returned invalid filter error: %s", testUrl)
 		return
@@ -84,7 +86,7 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(parsedUrl.Path, parsedUrl.Query(), false)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false)
 	if err != nil {
 		t.Error(err)
 		return
@@ -99,7 +101,7 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(parsedUrl.Path, parsedUrl.Query(), false)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false)
 	if err == nil {
 		t.Errorf("Parser should have returned invalid filter error: %s", testUrl)
 		return
@@ -111,7 +113,7 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(parsedUrl.Path, parsedUrl.Query(), false)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false)
 	if err != nil {
 		t.Error(err)
 		return
@@ -123,7 +125,7 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(parsedUrl.Path, parsedUrl.Query(), false /*strict*/)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false /*strict*/)
 	if err != nil {
 		t.Errorf("Unexpected parsing error: %v", err)
 		return
@@ -160,7 +162,7 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(parsedUrl.Path, parsedUrl.Query(), false /*strict*/)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false /*strict*/)
 	if err == nil {
 		t.Errorf("Parser should have raised error")
 		return
@@ -174,13 +176,13 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		return
 	}
 	// In lenient mode, do not return an error when there is a duplicate keyword.
-	_, err = ParseRequest(parsedUrl.Path, parsedUrl.Query(), true /*lenient*/)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), true /*lenient*/)
 	if err != nil {
 		t.Error(err)
 		return
 	}
 	// In strict mode, return an error when there is a duplicate keyword.
-	_, err = ParseRequest(parsedUrl.Path, parsedUrl.Query(), false /*strict*/)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false /*strict*/)
 	if err == nil {
 		t.Error("Parser should have returned duplicate keyword error")
 		return
@@ -193,12 +195,12 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(parsedUrl.Path, parsedUrl.Query(), true /*lenient*/)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), true /*lenient*/)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(parsedUrl.Path, parsedUrl.Query(), false /*strict*/)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false /*strict*/)
 	if err == nil {
 		t.Error("Parser should have returned unsupported keyword error")
 		return
@@ -210,7 +212,7 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(parsedUrl.Path, parsedUrl.Query(), false)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false)
 	if err != nil {
 		t.Error(err)
 		return
@@ -222,7 +224,7 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(parsedUrl.Path, parsedUrl.Query(), false)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false)
 	if err != nil {
 		t.Error(err)
 		return
@@ -498,9 +500,10 @@ func TestUnescapeStringTokens(t *testing.T) {
 			continue
 		}
 		t.Logf("Running test case %s", testCase.url)
-		var request *GoDataRequest
+
 		urlQuery := parsedUrl.Query()
-		request, err = ParseRequest(parsedUrl.Path, urlQuery, false /*strict*/)
+		ctx := context.Background()
+		request, err := ParseRequest(ctx, parsedUrl.Path, urlQuery, false /*strict*/)
 		if testCase.errRegex == nil && err != nil {
 			t.Errorf("Test case '%s' failed: %v", testCase.url, err)
 			continue

--- a/url_parser_test.go
+++ b/url_parser_test.go
@@ -17,7 +17,7 @@ func TestUrlParser(t *testing.T) {
 		return
 	}
 	ctx := context.Background()
-	request, err := ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false)
+	request, err := ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query())
 
 	if err != nil {
 		t.Error(err)
@@ -46,7 +46,7 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		return
 	}
 	ctx := context.Background()
-	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query())
 	if err != nil {
 		t.Error(err)
 		return
@@ -58,7 +58,7 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query())
 	if err != nil {
 		t.Error(err)
 		return
@@ -71,7 +71,7 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query())
 	if err == nil {
 		t.Errorf("Parser should have returned invalid filter error: %s", testUrl)
 		return
@@ -86,7 +86,7 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query())
 	if err != nil {
 		t.Error(err)
 		return
@@ -101,7 +101,7 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query())
 	if err == nil {
 		t.Errorf("Parser should have returned invalid filter error: %s", testUrl)
 		return
@@ -113,7 +113,7 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query())
 	if err != nil {
 		t.Error(err)
 		return
@@ -125,7 +125,7 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false /*strict*/)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query())
 	if err != nil {
 		t.Errorf("Unexpected parsing error: %v", err)
 		return
@@ -162,7 +162,7 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false /*strict*/)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query())
 	if err == nil {
 		t.Errorf("Parser should have raised error")
 		return
@@ -176,13 +176,14 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		return
 	}
 	// In lenient mode, do not return an error when there is a duplicate keyword.
-	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), true /*lenient*/)
+	lenientContext := WithOdataComplianceConfig(ctx, ComplianceIgnoreAll)
+	_, err = ParseRequest(lenientContext, parsedUrl.Path, parsedUrl.Query())
 	if err != nil {
 		t.Error(err)
 		return
 	}
 	// In strict mode, return an error when there is a duplicate keyword.
-	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false /*strict*/)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query())
 	if err == nil {
 		t.Error("Parser should have returned duplicate keyword error")
 		return
@@ -195,12 +196,12 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), true /*lenient*/)
+	_, err = ParseRequest(lenientContext, parsedUrl.Path, parsedUrl.Query())
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false /*strict*/)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query())
 	if err == nil {
 		t.Error("Parser should have returned unsupported keyword error")
 		return
@@ -212,7 +213,7 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query())
 	if err != nil {
 		t.Error(err)
 		return
@@ -224,7 +225,7 @@ func TestUrlParserStrictValidation(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query(), false)
+	_, err = ParseRequest(ctx, parsedUrl.Path, parsedUrl.Query())
 	if err != nil {
 		t.Error(err)
 		return
@@ -503,7 +504,7 @@ func TestUnescapeStringTokens(t *testing.T) {
 
 		urlQuery := parsedUrl.Query()
 		ctx := context.Background()
-		request, err := ParseRequest(ctx, parsedUrl.Path, urlQuery, false /*strict*/)
+		request, err := ParseRequest(ctx, parsedUrl.Path, urlQuery)
 		if testCase.errRegex == nil && err != nil {
 			t.Errorf("Test case '%s' failed: %v", testCase.url, err)
 			continue


### PR DESCRIPTION
1. Add `context.Context` as first argument of multiple parsing functions.
2. Change `GoDataRequest.RequestType` from int to derived type.
3. Add flags to control ODATA compliance check. For example, whether to accept or reject `f(a, b, c,)`
3. Add unit tests.