### PR TITLE
Add support for custom functions within odata query

### DIFF
--- a/filter_parser.go
+++ b/filter_parser.go
@@ -2,8 +2,8 @@ package godata
 
 import "context"
 
-var GlobalFilterTokenizer = NewExpressionTokenizer()
-var GlobalFilterParser = NewExpressionParser()
+var GlobalFilterTokenizer *Tokenizer
+var GlobalFilterParser *ExpressionParser
 
 // ParseFilterString converts an input string from the $filter part of the URL into a parse
 // tree that can be used by providers to create a response.

--- a/url_parser_test.go
+++ b/url_parser_test.go
@@ -551,6 +551,10 @@ func TestUnescapeStringTokens(t *testing.T) {
 		Name:      "discount",
 		NumParams: []int{1},
 	}})
+	if err != nil {
+		t.Errorf("Failed to add custom function: %v", err)
+		t.FailNow()
+	}
 
 	for _, testCase := range testCases {
 		var parsedUrl *url.URL

--- a/url_parser_test.go
+++ b/url_parser_test.go
@@ -519,6 +519,14 @@ func TestUnescapeStringTokens(t *testing.T) {
 			// todo: enhance fixture to handle $expand with embedded $compute and add assertions
 		},
 		{
+			url: "/Product?$compute=discount(Item/Price) as SalePrice",
+			expectedCompute: []ComputeItem{
+				{
+					Field: "SalePrice",
+				},
+			},
+		},
+		{
 			url:      "/Product?$compute=Price mul Quantity",
 			errRegex: regexp.MustCompile(`Invalid \$compute query option`),
 		},
@@ -539,6 +547,10 @@ func TestUnescapeStringTokens(t *testing.T) {
 			errRegex: regexp.MustCompile(`Invalid \$compute query option`),
 		},
 	}
+	DefineCustomFunctions([]CustomFunctionInput{{
+		Name:      "discount",
+		NumParams: []int{1},
+	}})
 
 	for _, testCase := range testCases {
 		parsedUrl, err := url.Parse(testCase.url)

--- a/url_parser_test.go
+++ b/url_parser_test.go
@@ -547,13 +547,14 @@ func TestUnescapeStringTokens(t *testing.T) {
 			errRegex: regexp.MustCompile(`Invalid \$compute query option`),
 		},
 	}
-	DefineCustomFunctions([]CustomFunctionInput{{
+	err := DefineCustomFunctions([]CustomFunctionInput{{
 		Name:      "discount",
 		NumParams: []int{1},
 	}})
 
 	for _, testCase := range testCases {
-		parsedUrl, err := url.Parse(testCase.url)
+		var parsedUrl *url.URL
+		parsedUrl, err = url.Parse(testCase.url)
 		if err != nil {
 			t.Errorf("Test case '%s' failed: %v", testCase.url, err)
 			continue
@@ -562,7 +563,8 @@ func TestUnescapeStringTokens(t *testing.T) {
 
 		urlQuery := parsedUrl.Query()
 		ctx := context.Background()
-		request, err := ParseRequest(ctx, parsedUrl.Path, urlQuery)
+		var request *GoDataRequest
+		request, err = ParseRequest(ctx, parsedUrl.Path, urlQuery)
 		if testCase.errRegex == nil && err != nil {
 			t.Errorf("Test case '%s' failed: %v", testCase.url, err)
 			continue


### PR DESCRIPTION
Add support for custom functions within odata query. Custom functions are functions not defined in the Odata specification which are specific to the service implementing an odata endpoint.

- Expose the package function DefineCustomFunctions() to allow applications using godata to introduce custom functions.
- Refactor the global tokenizer/parser variables to have only a single tokenizer and parse instance