### PR TITLE
Disallow extraneous commas in $expand $select $orderby query options

### DIFF
--- a/expand_parser.go
+++ b/expand_parser.go
@@ -162,6 +162,16 @@ func ParseExpandItem(ctx context.Context, input tokenQueue) (*ExpandItem, error)
 		item.Path = append(item.Path, queue.Dequeue())
 	}
 
+	cfg, hasComplianceConfig := ctx.Value(odataCompliance).(OdataComplianceConfig)
+	if !hasComplianceConfig {
+		// Strict ODATA compliance by default.
+		cfg = ComplianceStrict
+	}
+
+	if len(item.Path) == 0 && cfg&ComplianceIgnoreInvalidComma == 0 {
+		return nil, BadRequestError("Extra comma in $expand.")
+	}
+
 	return item, nil
 }
 

--- a/expand_parser_test.go
+++ b/expand_parser_test.go
@@ -121,3 +121,18 @@ func TestExpandNestedParens(t *testing.T) {
 		return
 	}
 }
+
+func TestExpandNegativeCases(t *testing.T) {
+	input := "Products," // Extraneous comma
+	ctx := context.Background()
+	output, err := ParseExpandString(ctx, input)
+
+	if err == nil {
+		t.Error("Expected parsing to return error.")
+		return
+	}
+	if output != nil {
+		t.Error("Expected parsing to return nil output.")
+		return
+	}
+}

--- a/orderby_parser.go
+++ b/orderby_parser.go
@@ -31,6 +31,17 @@ func (p *ExpressionParser) ParseOrderByString(ctx context.Context, orderby strin
 
 	for _, v := range items {
 		v = strings.TrimSpace(v)
+
+		cfg, hasComplianceConfig := ctx.Value(odataCompliance).(OdataComplianceConfig)
+		if !hasComplianceConfig {
+			// Strict ODATA compliance by default.
+			cfg = ComplianceStrict
+		}
+
+		if len(v) == 0 && cfg&ComplianceIgnoreInvalidComma == 0 {
+			return nil, BadRequestError("Extra comma in $orderby.")
+		}
+
 		var order string
 		vLower := strings.ToLower(v)
 		if strings.HasSuffix(vLower, " "+ASC) {

--- a/select_parser.go
+++ b/select_parser.go
@@ -16,6 +16,17 @@ func ParseSelectString(ctx context.Context, sel string) (*GoDataSelectQuery, err
 	result := []*SelectItem{}
 
 	for _, item := range items {
+
+		cfg, hasComplianceConfig := ctx.Value(odataCompliance).(OdataComplianceConfig)
+		if !hasComplianceConfig {
+			// Strict ODATA compliance by default.
+			cfg = ComplianceStrict
+		}
+
+		if len(strings.TrimSpace(item)) == 0 && cfg&ComplianceIgnoreInvalidComma == 0 {
+			return nil, BadRequestError("Extra comma in $select.")
+		}
+
 		segments := []*Token{}
 		for _, val := range strings.Split(item, "/") {
 			segments = append(segments, &Token{Value: val})

--- a/url_parser_test.go
+++ b/url_parser_test.go
@@ -501,7 +501,31 @@ func TestUnescapeStringTokens(t *testing.T) {
 			expectedOrderBy:    nil,
 		},
 		{
+			url:                "/Product?$orderby=Name,,Count",
+			errRegex:           regexp.MustCompile(`Extra comma in \$orderby\.`),
+			expectedFilterTree: nil,
+			expectedOrderBy:    nil,
+		},
+		{
+			url:                "/Product?$orderby=,Name",
+			errRegex:           regexp.MustCompile(`Extra comma in \$orderby\.`),
+			expectedFilterTree: nil,
+			expectedOrderBy:    nil,
+		},
+		{
 			url:                "/Product?$select=Name,",
+			errRegex:           regexp.MustCompile(`Extra comma in \$select\.`),
+			expectedFilterTree: nil,
+			expectedOrderBy:    nil,
+		},
+		{
+			url:                "/Product?$select=Name,,Count",
+			errRegex:           regexp.MustCompile(`Extra comma in \$select\.`),
+			expectedFilterTree: nil,
+			expectedOrderBy:    nil,
+		},
+		{
+			url:                "/Product?$select=,Name",
 			errRegex:           regexp.MustCompile(`Extra comma in \$select\.`),
 			expectedFilterTree: nil,
 			expectedOrderBy:    nil,

--- a/url_parser_test.go
+++ b/url_parser_test.go
@@ -495,6 +495,18 @@ func TestUnescapeStringTokens(t *testing.T) {
 			expectedOrderBy:    nil,
 		},
 		{
+			url:                "/Product?$orderby=Name,",
+			errRegex:           regexp.MustCompile(`Extra comma in \$orderby\.`),
+			expectedFilterTree: nil,
+			expectedOrderBy:    nil,
+		},
+		{
+			url:                "/Product?$select=Name,",
+			errRegex:           regexp.MustCompile(`Extra comma in \$select\.`),
+			expectedFilterTree: nil,
+			expectedOrderBy:    nil,
+		},
+		{
 			url:      "/Product?$compute=Price mul Quantity as TotalPrice",
 			errRegex: nil,
 			expectedCompute: []ComputeItem{


### PR DESCRIPTION
Disallow extraneous commas when the `ComplianceIgnoreInvalidComma` compliance flag is set in the Go context (ie `ctx` function argument in the `godata.ParseRequest()` function). 

For example disallow `$select=Name,,Description` and `$orderby=Name desc,`

Extraneous commas were previously allowed and translated into godata parse structures representing the 'empty value' of the respective query option. Applications using the godata library needed to check and ignore (or otherwise handle) such 'empty values'. Applications which did not check these conditions could encounter runtime failures such as panics. 