### PR TITLE
Support 'case' statement

### DIFF
--- a/compute_parser_test.go
+++ b/compute_parser_test.go
@@ -33,6 +33,13 @@ func TestParseCompute(t *testing.T) {
 		{[]string{"twoArgFunc(one, two) as newField"}, true},
 		{[]string{"twoArgFunc(one, two) as newField", "tolower(three) as  newFieldTwo"}, true},
 
+		{[]string{"case(false:0) as newField"}, true},
+		{[]string{"case(false:0,true:1) as newField"}, true},
+		{[]string{"case(prop eq 'one':1,prop eq 'two':2) as newField"}, true},
+		{[]string{"case(tolower(one) eq one:'lower') as newField"}, true},
+		{[]string{"case(contains(haystack,'needle'):1,true:1) as newField"}, true},
+		{[]string{"case(false:1,false:2,false:3,false:4,false:5,false:6,false:7,false:8,false:9,false:10) as newField"}, true}, // max of 10 cases
+
 		// negative cases
 		{[]string{"one add two as newField2"}, false},
 		{[]string{"one add two newField2"}, false},
@@ -40,6 +47,15 @@ func TestParseCompute(t *testing.T) {
 		{[]string{"as"}, false},
 		{[]string{"as newField"}, false},
 		{[]string{"zeroArgFunc() as "}, false},
+
+		{[]string{"case as newField"}, false},
+		{[]string{"case() as newField"}, false},
+		{[]string{"case(false:,true:1) as newField"}, false},
+		{[]string{"case(false,true:1) as newField"}, false},
+		{[]string{"case(false,true:1) as newField"}, false},
+		{[]string{"case(1:1,true:1) as newField"}, false},
+		{[]string{"case(1:1,true:1) as newField"}, false},
+		{[]string{"case(false:1,false:2,false:3,false:4,false:5,false:6,false:7,false:8,false:9,false:10,false:11) as newField"}, false}, // max of 10 cases
 	}
 
 	for i, v := range testCases {

--- a/compute_parser_test.go
+++ b/compute_parser_test.go
@@ -38,6 +38,8 @@ func TestParseCompute(t *testing.T) {
 		{[]string{"case(prop eq 'one':1,prop eq 'two':2) as newField"}, true},
 		{[]string{"case(tolower(one) eq one:'lower') as newField"}, true},
 		{[]string{"case(contains(haystack,'needle'):1,true:1) as newField"}, true},
+		{[]string{"case(tolower(one) eq one:tolower(one)) as newField"}, true},
+		{[]string{"case(true:2 mul 3) as newField"}, true},
 		{[]string{"case(false:1,false:2,false:3,false:4,false:5,false:6,false:7,false:8,false:9,false:10) as newField"}, true}, // max of 10 cases
 
 		// negative cases

--- a/expression_parser.go
+++ b/expression_parser.go
@@ -42,21 +42,23 @@ const (
 	ExpressionTokenFunc                                        // Function, e.g. contains, substring...
 	ExpressionTokenLambdaNav                                   // "/" token when used in lambda expression, e.g. tags/any()
 	ExpressionTokenLambda                                      // [10] any(), all() lambda functions
+	ExpressionTokenCase                                        // A case() statement. See https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_case
+	ExpressionTokenCasePair                                    // A case statement expression pair [ <boolean expression> : <value expression> ]
 	ExpressionTokenNull                                        //
 	ExpressionTokenIt                                          // The '$it' token
-	ExpressionTokenRoot                                        // The '$root' token
+	ExpressionTokenRoot                                        // [15] The '$root' token
 	ExpressionTokenFloat                                       // A floating point value.
-	ExpressionTokenInteger                                     // [15] An integer value
+	ExpressionTokenInteger                                     // An integer value
 	ExpressionTokenString                                      // SQUOTE *( SQUOTE-in-string / pchar-no-SQUOTE ) SQUOTE
 	ExpressionTokenDate                                        // A date value
-	ExpressionTokenTime                                        // A time value
+	ExpressionTokenTime                                        // [20] A time value
 	ExpressionTokenDateTime                                    // A date-time value
-	ExpressionTokenBoolean                                     // [20]
-	ExpressionTokenLiteral                                     //
+	ExpressionTokenBoolean                                     // A literal boolean value
+	ExpressionTokenLiteral                                     // A literal non-boolean value
 	ExpressionTokenDuration                                    // duration      = [ "duration" ] SQUOTE durationValue SQUOTE
-	ExpressionTokenGuid                                        // A 128-bit GUID
+	ExpressionTokenGuid                                        // [25] A 128-bit GUID
 	ExpressionTokenAssignement                                 // The '=' assignement for function arguments.
-	ExpressionTokenGeographyPolygon                            // [25]
+	ExpressionTokenGeographyPolygon                            //
 	ExpressionTokenGeometryPolygon                             //
 	expressionTokenLast
 )
@@ -74,6 +76,8 @@ func (e ExpressionTokenType) String() string {
 		"ExpressionTokenFunc",
 		"ExpressionTokenLambdaNav",
 		"ExpressionTokenLambda",
+		"ExpressionTokenCase",
+		"ExpressionTokenCasePair",
 		"ExpressionTokenNull",
 		"ExpressionTokenIt",
 		"ExpressionTokenRoot",
@@ -205,6 +209,7 @@ func NewExpressionTokenizer() *Tokenizer {
 	// anyExpr = "any" OPEN BWS [ lambdaVariableExpr BWS COLON BWS lambdaPredicateExpr ] BWS CLOSE
 	// allExpr = "all" OPEN BWS   lambdaVariableExpr BWS COLON BWS lambdaPredicateExpr   BWS CLOSE
 	t.Add("(?i)^(?P<token>(any|all))[\\s(]", ExpressionTokenLambda)
+	t.Add("(?i)^(?P<token>(case))[\\s(]", ExpressionTokenCase)
 	t.Add("^null", ExpressionTokenNull)
 	t.Add("^\\$it", ExpressionTokenIt)
 	t.Add("^\\$root", ExpressionTokenRoot)
@@ -322,6 +327,9 @@ func NewExpressionParser() *ExpressionParser {
 	parser.DefineFunction("any", []int{0, 2}, true)
 	// 'all' requires two arguments of a form similar to 'any'.
 	parser.DefineFunction("all", []int{2}, true)
+	// Define 'case' as a function accepting 1-10 arguments. Each argument is a pair of expressions separated by a colon.
+	// See https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_case
+	parser.DefineFunction("case", []int{1,2,3,4,5,6,7,8,9,10}, true)
 
 	return parser
 }

--- a/expression_parser_fixture_test.go
+++ b/expression_parser_fixture_test.go
@@ -77,6 +77,46 @@ var testCases = []struct {
 		},
 	},
 	{
+		expression: "case(false:0,true:1)",
+		tree: []expectedParseNode{
+			{Value: "case", Depth: 0, Type: ExpressionTokenCase},
+			{Value: "", Depth: 1, Type: ExpressionTokenCasePair},
+			{Value: "false", Depth: 2, Type: ExpressionTokenBoolean},
+			{Value: "0", Depth: 2, Type: ExpressionTokenInteger},
+			{Value: "", Depth: 1, Type: ExpressionTokenCasePair},
+			{Value: "true", Depth: 2, Type: ExpressionTokenBoolean},
+			{Value: "1", Depth: 2, Type: ExpressionTokenInteger},
+		},
+	},
+	{
+		expression: "case(prop eq 'one':1,true:0)",
+		tree: []expectedParseNode{
+			{Value: "case", Depth: 0, Type: ExpressionTokenCase},
+			{Value: "", Depth: 1, Type: ExpressionTokenCasePair},
+			{Value: "eq", Depth: 2, Type: ExpressionTokenLogical},
+			{Value: "prop", Depth: 3, Type: ExpressionTokenLiteral},
+			{Value: "'one'", Depth: 3, Type: ExpressionTokenString},
+			{Value: "1", Depth: 2, Type: ExpressionTokenInteger},
+			{Value: "", Depth: 1, Type: ExpressionTokenCasePair},
+			{Value: "true", Depth: 2, Type: ExpressionTokenBoolean},
+			{Value: "0", Depth: 2, Type: ExpressionTokenInteger},
+		},
+	},
+	{
+		expression: "case(contains(prop,'val'):0,true:1)",
+		tree: []expectedParseNode{
+			{Value: "case", Depth: 0, Type: ExpressionTokenCase},
+			{Value: "", Depth: 1, Type: ExpressionTokenCasePair},
+			{Value: "contains", Depth: 2, Type: ExpressionTokenFunc},
+			{Value: "prop", Depth: 3, Type: ExpressionTokenLiteral},
+			{Value: "'val'", Depth: 3, Type: ExpressionTokenString},
+			{Value: "0", Depth: 2, Type: ExpressionTokenInteger},
+			{Value: "", Depth: 1, Type: ExpressionTokenCasePair},
+			{Value: "true", Depth: 2, Type: ExpressionTokenBoolean},
+			{Value: "1", Depth: 2, Type: ExpressionTokenInteger},
+		},
+	},
+	{
 		/*
 			{
 				"Tags": [

--- a/expression_parser_test.go
+++ b/expression_parser_test.go
@@ -246,6 +246,7 @@ func TestInvalidBooleanExpressionSyntax(t *testing.T) {
 		"now()",
 		"tolower(Name)",
 		"concat(First,Last)",
+		"case(false:0,true:1)",
 	}
 	p := NewExpressionParser()
 	p.ExpectBoolExpr = true


### PR DESCRIPTION
Support 'case' statement as defined at https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_case. This PR's implementation supports up to 10 cases in the case statement.

The parse-tree representation of 'case' is a node of type ExpressionTokenCase, containing a list of ExpressionTokenCasePair nodes, one for each colon-delimited expression pair. Each ExpressionTokenCasePair node has two children. Child 0 is the boolean expression and child 1 is the value expression.