### PR TITLE
Fix treatment of boolean expressions

### DIFF
--- a/expression_parser.go
+++ b/expression_parser.go
@@ -315,7 +315,7 @@ func NewExpressionParser() *ExpressionParser {
 	//   Edm.Boolean geo.intersects(Edm.GeometryPoint,Edm.GeometryPolygon)
 	// The geo.intersects function returns true if the specified point lies within the interior
 	// or on the boundary of the specified polygon, otherwise it returns false.
-	parser.DefineFunction("geo.intersects", []int{2}, false)
+	parser.DefineFunction("geo.intersects", []int{2}, true)
 	// The geo.length function has the following signatures:
 	//   Edm.Double geo.length(Edm.GeographyLineString)
 	//   Edm.Double geo.length(Edm.GeometryLineString)
@@ -329,7 +329,7 @@ func NewExpressionParser() *ExpressionParser {
 	parser.DefineFunction("all", []int{2}, true)
 	// Define 'case' as a function accepting 1-10 arguments. Each argument is a pair of expressions separated by a colon.
 	// See https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_case
-	parser.DefineFunction("case", []int{1,2,3,4,5,6,7,8,9,10}, true)
+	parser.DefineFunction("case", []int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, true)
 
 	return parser
 }

--- a/expression_parser_test.go
+++ b/expression_parser_test.go
@@ -241,8 +241,6 @@ func TestInvalidBooleanExpressionSyntax(t *testing.T) {
 		// Geo functions
 		"geo.distance(CurrentPosition,TargetPosition)",
 		"geo.length(DirectRoute)",
-		"geo.intersects(Position,TargetArea)",
-		"GEO.INTERSECTS(Position,TargetArea)", // functions are case insensitive in ODATA 4.0.1
 		"now()",
 		"tolower(Name)",
 		"concat(First,Last)",

--- a/filter_parser.go
+++ b/filter_parser.go
@@ -21,8 +21,7 @@ func ParseFilterString(ctx context.Context, filter string) (*GoDataFilterQuery, 
 	if err != nil {
 		return nil, err
 	}
-	if tree == nil || tree.Token == nil ||
-		(len(tree.Children) == 0 && tree.Token.Type != ExpressionTokenBoolean) {
+	if tree == nil || tree.Token == nil || !GlobalFilterParser.isBooleanExpression(tree.Token) {
 		return nil, BadRequestError("Value must be a boolean expression")
 	}
 	return &GoDataFilterQuery{tree, filter}, nil

--- a/filter_parser_test.go
+++ b/filter_parser_test.go
@@ -696,7 +696,9 @@ func TestFilterInOperatorEmptyList(t *testing.T) {
 
 // TestFilterInOperatorBothSides tests the "IN" operator.
 // Use a listExpr on both sides of the IN operator.
-//   listExpr  = OPEN BWS commonExpr BWS *( COMMA BWS commonExpr BWS ) CLOSE
+//
+//	listExpr  = OPEN BWS commonExpr BWS *( COMMA BWS commonExpr BWS ) CLOSE
+//
 // Validate if a list is within another list.
 func TestFilterInOperatorBothSides(t *testing.T) {
 	ctx := context.Background()
@@ -1178,13 +1180,12 @@ func TestValidFilterSyntax(t *testing.T) {
 		// Type functions
 		"isof(ShipCountry,Edm.String)",
 		"isof(NorthwindModel.BigOrder)",
-		"cast(ShipCountry,Edm.String)",
 		// Parameter aliases
 		// See http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part1-protocol/odata-v4.0-errata03-os-part1-protocol-complete.html#_Toc453752288
 		"Region eq @p1", // Aliases start with @
 		// Geo functions
-		"geo.distance(CurrentPosition,TargetPosition)",
-		"geo.length(DirectRoute)",
+		"geo.distance(CurrentPosition,TargetPosition) gt 32.1",
+		"geo.length(DirectRoute) eq 32.1",
 		"geo.intersects(Position,TargetArea)",
 		"GEO.INTERSECTS(Position,TargetArea)", // functions are case insensitive in ODATA 4.0.1
 		// Logical operators
@@ -1312,23 +1313,23 @@ func TestInvalidFilterSyntax(t *testing.T) {
 		"not (City eq 'Dallas'))",              // Extraneous closing parenthesis
 		"not City eq 'Dallas')",                // Missing open parenthesis
 		"City eq 'Dallas' orCity eq 'Houston'", // missing space between or and City
-		// TODO: the query below should fail.
-		//"Tags/any(var:var/Key eq 'Site') orTags/any(var:var/Key eq 'Site')",
+		"Tags/any(var:var/Key eq 'Site') orTags/any(var:var/Key eq 'Site')",
 		"not (City eq 'Dallas') and Name eq 'Houston')",
-		"Tags/all()",                   // The all operator cannot be used without an argument expression.
-		"LastName contains 'Smith'",    // Previously the godata library was not returning an error.
-		"contains",                     // Function with missing parenthesis and arguments
-		"contains()",                   // Function with missing arguments
-		"contains LastName, 'Smith'",   // Missing parenthesis
-		"contains(LastName)",           // Insufficent number of function arguments
-		"contains(LastName, 'Smith'))", // Extraneous closing parenthesis
-		"contains(LastName, 'Smith'",   // Missing closing parenthesis
-		"contains LastName, 'Smith')",  // Missing open parenthesis
-		"City eq 'Dallas' 'Houston'",   // extraneous string value
-		"(numCore neq 12)",             // Invalid operator. It should be 'ne'
-		"(a b c d)",                    // Invalid list
-		"numCore neq 12",               // Invalid operator. It should be 'ne'
-		//"contains(Name, 'a', 'b', 'c', 'd')", // Too many function arguments
+		"Tags/all()",                         // The all operator cannot be used without an argument expression.
+		"LastName contains 'Smith'",          // Previously the godata library was not returning an error.
+		"contains",                           // Function with missing parenthesis and arguments
+		"contains()",                         // Function with missing arguments
+		"contains LastName, 'Smith'",         // Missing parenthesis
+		"contains(LastName)",                 // Insufficent number of function arguments
+		"contains(LastName, 'Smith'))",       // Extraneous closing parenthesis
+		"contains(LastName, 'Smith'",         // Missing closing parenthesis
+		"contains LastName, 'Smith')",        // Missing open parenthesis
+		"City eq 'Dallas' 'Houston'",         // extraneous string value
+		"(numCore neq 12)",                   // Invalid operator. It should be 'ne'
+		"(a b c d)",                          // Invalid list
+		"numCore neq 12",                     // Invalid operator. It should be 'ne'
+		"contains(Name, 'a', 'b', 'c', 'd')", // Too many function arguments
+		"length('Doe')",                      // non-boolean return value
 	}
 	ctx := context.Background()
 	for _, input := range queries {


### PR DESCRIPTION
- Fail $filter expression parsing for non-boolean expressions
- Classify geo.intersects() function as returning a boolean value
- Correct test cases related to classification of boolean expresions/filters
- Format with gofmt